### PR TITLE
remove maintainers from main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,3 @@ white_list_helm_chart_container_names:
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
-
-## Maintainers
-
-  - [W. Watson](https://github.com/wavell) - creator and maintainer
-  - [Joshua Darius](https://github.com/nupejosh) - creator and maintainer
-  - [Denver Williams](https://github.com/denverwilliams) - creator and maintainer
-  - [William Harris](https://github.com/williscool) - creator and maintainer
-  - [Taylor Carpenter](https://github.com/taylor) - creator and maintainer
-  - [Lucina Stricko](https://github.com/lixuna) - maintainer


### PR DESCRIPTION

## Description
#48 
- remove maintainers from main readme
- maintainers are listed in https://github.com/cncf/cnf-conformance/blob/master/MAINTAINERS.md


## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ]  Tested manually
   * [ ] tag
   * [ ] master
   * [ ] develop
* [] Tested locally on a shared K8s cluster
* [] Tested locally on a new K8s cluster
* [x]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* []  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* []  My change requires a change to the documentation.
* [x]  I have updated the documentation accordingly.
* [] No updates required.

