### PR TITLE
Merge fix incorrect message for setup of sample CNF

### DIFF
--- a/src/tasks/sample_coredns_setup.cr
+++ b/src/tasks/sample_coredns_setup.cr
@@ -131,18 +131,13 @@ task "bad_helm_cnf_setup", ["helm_local_install"] do |_, args|
   end
 end
 
-task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_, args|
+task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, args|
   current_dir = FileUtils.pwd 
   puts current_dir if check_verbose(args)
 
-  # Retrieve the cnf source
-  # TODO enable recloning/fetching etc
-  # git_clone = `git clone https://github.com/coredns/coredns.git #{current_dir}/#{CNF_DIR}/coredns`    
-  # puts git_clone if check_verbose(args)
-
   # Copy the chart into the cnfs directory and use the correct cnf-conformance.yml
   chart_cp = `cp -r #{current_dir}/sample-cnfs/sample_privileged_cnf_setup_coredns #{current_dir}/#{CNF_DIR}/`
-  yml_mv = `mv #{current_dir}/#{CNF_DIR}/sample_privileged_cnf_setup_coredns/non-whitelisted-conformance.yml #{current_dir}/#{CNF_DIR}/sample_privileged_cnf_setup_coredns/cnf-conformance.yml`
+  yml_mv = `mv #{current_dir}/#{CNF_DIR}/sample_privileged_cnf_setup_coredns/whitelisted-conformance.yml #{current_dir}/#{CNF_DIR}/sample_privileged_cnf_setup_coredns/cnf-conformance.yml`
   puts chart_cp if check_verbose(args)
   puts yml_mv if check_verbose(args)
 
@@ -179,7 +174,7 @@ task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_
 
     wait_for_install(deployment_name)
     if helm_install.to_s.size > 0
-      puts "Successfully setup sample_privileged_cnf_non_whitelisted".colorize(:green)
+      puts "Successfully setup sample_privileged_cnf_whitelisted_setup".colorize(:green)
     end
   ensure
     cd = `cd #{current_dir}`
@@ -187,7 +182,7 @@ task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_
   end
 end
 
-task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, args|
+task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_, args|
   current_dir = FileUtils.pwd 
   puts current_dir if check_verbose(args)
 
@@ -235,7 +230,7 @@ task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, ar
 
     wait_for_install(deployment_name)
     if helm_install.to_s.size > 0
-      puts "Successfully setup sample_privileged_cnf_non_whitelisted".colorize(:green)
+      puts "Successfully setup sample_privileged_cnf_non_whitelisted_setup".colorize(:green)
     end
   ensure
     cd = `cd #{current_dir}`
@@ -263,6 +258,15 @@ task "bad_helm_cnf_cleanup" do |_, args|
   puts rm if check_verbose(args)
 end
 
+task "sample_privileged_cnf_whitelisted_cleanup" do |_, args|
+  current_dir = FileUtils.pwd 
+  helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
+  puts helm if check_verbose(args)
+  helm_uninstall = `#{helm} uninstall privileged-coredns`
+  puts helm_uninstall if check_verbose(args)
+  rm = `rm -rf #{current_dir}/#{CNF_DIR}/sample_privileged_cnf_setup_coredns`
+  puts rm if check_verbose(args)
+end
 
 task "sample_privileged_cnf_non_whitelisted_cleanup" do |_, args|
   current_dir = FileUtils.pwd 


### PR DESCRIPTION
# Fixing sample CNF setup tasks for privileged mode tests

## Description

Updates messaging for setup tasks for the sample CNFs including deploy

Cherry-picking commits from `develop`
- https://github.com/cncf/cnf-conformance/commit/2259eb68df56750b4d79c5e3296b5839da6fb986

closes #55 

## Issues:
- https://github.com/cncf/cnf-conformance/issues/55

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [x] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [x] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
