### PR TITLE
rolling update conformance test

### DIFF
--- a/sample-cnfs/sample-coredns-cnf/cnf-conformance.yml
+++ b/sample-cnfs/sample-coredns-cnf/cnf-conformance.yml
@@ -8,4 +8,5 @@ deployment_name: coredns-coredns
 application_deployment_names: [coredns-coredns]
 helm_chart: stable/coredns
 helm_chart_container_name: coredns
+helm_chart_image_repository_version: latest
 white_list_helm_chart_container_names: [falco, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample-coredns-cnf/cnf-conformance.yml
+++ b/sample-cnfs/sample-coredns-cnf/cnf-conformance.yml
@@ -8,5 +8,5 @@ deployment_name: coredns-coredns
 application_deployment_names: [coredns-coredns]
 helm_chart: stable/coredns
 helm_chart_container_name: coredns
-helm_chart_image_repository_version: latest
+cnf_image_version: latest
 white_list_helm_chart_container_names: [falco, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/sample-cnfs/sample_coredns/cnf-conformance.yml
+++ b/sample-cnfs/sample_coredns/cnf-conformance.yml
@@ -7,4 +7,5 @@ deployment_name: coredns-coredns
 application_deployment_names: [coredns-coredns]
 helm_chart: stable/coredns
 helm_chart_container_name: coredns-coredns
+helm_chart_image_repository_version: latest
 white_list_helm_chart_container_names: []

--- a/sample-cnfs/sample_coredns/cnf-conformance.yml
+++ b/sample-cnfs/sample_coredns/cnf-conformance.yml
@@ -7,5 +7,5 @@ deployment_name: coredns-coredns
 application_deployment_names: [coredns-coredns]
 helm_chart: stable/coredns
 helm_chart_container_name: coredns-coredns
-helm_chart_image_repository_version: latest
+cnf_image_version: latest
 white_list_helm_chart_container_names: []

--- a/spec/configuration_lifecycle_spec.cr
+++ b/spec/configuration_lifecycle_spec.cr
@@ -72,4 +72,28 @@ describe CnfConformance do
       `crystal src/cnf-conformance.cr sample_coredns_bad_liveness_cleanup`
     end
   end
+  it "'rolling_update' should pass when valid version is given", tags: "rolling_update" do
+    begin
+      `crystal src/cnf-conformance.cr sample_coredns`
+      $?.success?.should be_true
+      response_s = `crystal src/cnf-conformance.cr rolling_update verbose`
+      puts response_s
+      $?.success?.should be_true
+      (/Rolling Update Passed/ =~ response_s).should_not be_nil
+    ensure
+      `crystal src/cnf-conformance.cr cleanup_sample_coredns`
+    end
+  end
+  it "'rolling_update' should fail when invalid version is given", tags: "rolling_update" do
+    begin
+      `crystal src/cnf-conformance.cr sample_coredns`
+      $?.success?.should be_true
+      response_s = `crystal src/cnf-conformance.cr rolling_update verbose version_tag=this_is_not_real_version`
+      puts response_s
+      $?.success?.should be_true
+      (/Rolling Update Failed/ =~ response_s).should_not be_nil
+    ensure
+      `crystal src/cnf-conformance.cr cleanup_sample_coredns`
+    end
+  end
 end

--- a/src/tasks/configuration_lifecycle.cr
+++ b/src/tasks/configuration_lifecycle.cr
@@ -151,9 +151,11 @@ task "rolling_update" do |_, args|
     puts "rolling_update" if check_verbose(args)
     config = cnf_conformance_yml
 
-    raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag" unless args.raw.includes? "version_tag"
+    unless args.named.has_key? "version_tag"
+      raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag"
+    end
 
-    version_tag = args["version_tag"]
+    version_tag = args.named["version_tag"]
     release_name = config.get("release_name").as_s
     deployment_name = config.get("deployment_name").as_s
 

--- a/src/tasks/configuration_lifecycle.cr
+++ b/src/tasks/configuration_lifecycle.cr
@@ -153,8 +153,8 @@ task "rolling_update" do |_, args|
 
     version_tag = nil
 
-    if config.has_key? "helm_chart_image_repository_version"
-      version_tag = config.get("helm_chart_image_repository_version").as_s
+    if config.has_key? "cnf_image_version"
+      version_tag = config.get("cnf_image_version").as_s
     end
 
     if args.named.has_key? "version_tag"
@@ -162,7 +162,7 @@ task "rolling_update" do |_, args|
     end
     
     unless version_tag
-      raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag or with cnf_conformance_yml option 'helm_chart_image_repository_version'"
+      raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag or with cnf_conformance_yml option 'cnf_image_version'"
     end
 
     release_name = config.get("release_name").as_s

--- a/src/tasks/configuration_lifecycle.cr
+++ b/src/tasks/configuration_lifecycle.cr
@@ -2,6 +2,7 @@ require "sam"
 require "file_utils"
 require "colorize"
 require "totem"
+require "json"
 require "./utils.cr"
 
 desc "Configuration and lifecycle should be managed in a declarative manner, using ConfigMaps, Operators, or other declarative interfaces."
@@ -136,6 +137,48 @@ task "retrieve_manifest" do |_, args|
     puts destination_cnf_dir if check_verbose(args)
     manifest = `kubectl get deployment #{deployment_name} -o yaml  > #{destination_cnf_dir}/#{helm_directory}/manifest.yml`
     puts manifest if check_verbose(args)
+  rescue ex
+    puts ex.message
+    ex.backtrace.each do |x|
+      puts x
+    end
+  end
+end
+
+desc "Test if the CNF can perform a rolling update"
+task "rolling_update" do |_, args|
+  begin
+    puts "rolling_update" if check_verbose(args)
+    config = cnf_conformance_yml
+
+    raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag" unless args.raw.includes? "version_tag"
+
+    version_tag = args["version_tag"]
+    release_name = config.get("release_name").as_s
+    deployment_name = config.get("deployment_name").as_s
+
+    helm_chart_values = JSON.parse(`helm get values #{release_name} -a -o json`)
+    puts "helm_chart_values" if check_verbose(args)
+    puts helm_chart_values if check_verbose(args)
+    image_name = helm_chart_values["image"]["repository"]
+
+    puts "image_name: #{image_name}" if check_verbose(args)
+
+    puts "rolling_update: setting new version" if check_verbose(args)
+    #do_update = `kubectl set image deployment/coredns-coredns coredns=coredns/coredns:latest --record`
+    puts "kubectl set image deployment/#{deployment_name} #{release_name}=#{image_name}:#{version_tag} --record" if check_verbose(args)
+    do_update = `kubectl set image deployment/#{deployment_name} #{release_name}=#{image_name}:#{version_tag} --record`
+
+    # https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rolling-update
+    puts "rolling_update: checking status new version" if check_verbose(args)
+    puts `kubectl rollout status deployment/#{deployment_name} --timeout=30s`
+
+    if $?.success?
+      puts "PASSED: CNF #{deployment_name} Rolling Update Passed".colorize(:green)
+    else
+      puts "FAILURE: CNF #{deployment_name} Rolling Update Failed".colorize(:red)
+    end
+
   rescue ex
     puts ex.message
     ex.backtrace.each do |x|

--- a/src/tasks/configuration_lifecycle.cr
+++ b/src/tasks/configuration_lifecycle.cr
@@ -151,11 +151,20 @@ task "rolling_update" do |_, args|
     puts "rolling_update" if check_verbose(args)
     config = cnf_conformance_yml
 
-    unless args.named.has_key? "version_tag"
-      raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag"
+    version_tag = nil
+
+    if args.named.has_key? "version_tag"
+      version_tag = args.named["version_tag"]
     end
 
-    version_tag = args.named["version_tag"]
+    if config.has_key? "helm_chart_image_repository_version"
+      version_tag = config.get("helm_chart_image_repository_version").as_s
+    end
+
+    unless version_tag
+      raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag or with cnf_conformance_yml option 'helm_chart_image_repository_version'"
+    end
+
     release_name = config.get("release_name").as_s
     deployment_name = config.get("deployment_name").as_s
 

--- a/src/tasks/configuration_lifecycle.cr
+++ b/src/tasks/configuration_lifecycle.cr
@@ -153,14 +153,14 @@ task "rolling_update" do |_, args|
 
     version_tag = nil
 
-    if args.named.has_key? "version_tag"
-      version_tag = args.named["version_tag"]
-    end
-
     if config.has_key? "helm_chart_image_repository_version"
       version_tag = config.get("helm_chart_image_repository_version").as_s
     end
 
+    if args.named.has_key? "version_tag"
+      version_tag = args.named["version_tag"]
+    end
+    
     unless version_tag
       raise "FAILURE: please specify a version of the CNF's release's image with the option version_tag or with cnf_conformance_yml option 'helm_chart_image_repository_version'"
     end


### PR DESCRIPTION
usage:

```
crystal src/cnf-conformance.cr rolling_update -- version_tag=latest
```

where version_tags value is a valid release name for the image set in
the helm chart's configuration

i.e. for the coredns stable chart
https://github.com/helm/charts/tree/master/stable/coredns#configuration

the image is `coredns/coredns`

and the version is `v1.6.7`

but any valid version tag from docker hub

https://hub.docker.com/r/coredns/coredns/tags

can be used

refs #7

# CNF Conformance PR Template

## Description
(name of issue/change)

## Issues:
- https://github.com/cncf/cnf-conformance/issues/NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
