### PR TITLE
Added CNF setup and cleanup instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,13 +130,12 @@ crystal build src/cnf-conformance.cr --release
 - [Access](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/) to a working [Certified K8s](https://cncf.io/ck) cluster via [KUBECONFIG environment variable](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable). (See [K8s Getting started guide](https://kubernetes.io/docs/setup/) for options)
     - `export KUBECONFIG=$HOME/mycluster.config`
     - Running `kubectl cluster-info` should show a running Kubernetes master in the output
-- Deploy CNF to cluster.  Eg. `helm install coredns stable/coredns`
-    - _Note: Not automated at this time_
-
+- CNF must have a helm chart
+  - To pass all current tests
+  - To support auto deployment of CNF from configuration ([docs](https://github.com/cncf/cnf-conformance/blob/master/CNF_CONFORMANCE_YML_USAGE.md))
 
 
 ## Setup and configuration
-
 
 ### Download/Install the conformance suite
 
@@ -151,32 +150,17 @@ crystal build src/cnf-conformance.cr --release
 
 ### Configure the conformance suite for testing a CNF
 - Initialize the test suite by running `cnf-conformance setup` (creates cnfs folder and other items)
-- Create a folder under the `cnfs/` directory for your CNF. Eg. `cnfs/my_layer4_proxy_cnf` or `cnfs/my_ipsec_cnf`
 - Create a Conformance configuration file called `cnf-confromance.yml` under the your CNF folder (eg. `cnfs/my_ipsec_cnf/cnf-conformance.yml`)
-  - Example config (See [latest example in repo](https://github.com/cncf/cnf-conformance/blob/master/cnf-conformance-example.yml)): 
-```   
----
-# Local copy of CNFs Helm chart
-helm_directory: cnfs/coredns/helm_chart/coredns
-# Publishd Helm chart name for CNF
-helm_chart: stable/coredns
-# Container name in deployment pod spec
-helm_chart_container_name: coredns
-git_clone_url: 
-install_script: coredns/Makefile
-release_name: coredns
-deployment_name: coredns-coredns 
-application_deployment_names: [coredns-coredns]
-cnf_image_version: latest
-white_list_helm_chart_container_names: [falco, nginx, coredns, calico-node, kube-proxy, nginx-proxy]
-```
-  - Optionally, copy the example configuration file, `cnf-conformance-example.yml`, and modify appropriately
+  - See example config (See [latest example in repo](https://github.com/cncf/cnf-conformance/blob/master/cnf-conformance.example.yml)): 
+    - Optionally, copy the example configuration file, [`cnf-conformance-example.yml`](https://github.com/cncf/cnf-conformance/blob/master/cnf-conformance.example.yml), and modify appropriately
+- Setup your CNF for testing and deploy it to the cluster by running `crystal src/cnf-conformance.cr cnf_setup cnf-path=path_to_your/cnf_folder`
+    - _NOTE: if you do not want to automatically deploy the using the helm chart defined in the configuration then you MUST pass `deploy_with_chart=false` to the `cnf_setup` command._
 
 
 ## Running and checking results for the Conformance testing
 
 
-**Running the suite**
+**Running all tests**
 
 ```
 cnf-conformance all
@@ -188,3 +172,11 @@ In the console where the test suite runs:
 - PASSED or FAILED will be displayed for the tests
 
 A test log file, eg. `cnf-conformance-results-20200401.txt`, will be created which lists PASS or FAIL for every test
+
+**Cleaning up**
+
+Run `crystal src/cnf-conformance.cr cnf_cleanup cnf-path=path_to_your/cnf_folder` 
+
+_NOTE: Does not handle manually deployed CNFs_
+
+


### PR DESCRIPTION
# Updated CNF Developer docs for new prereqs and commands

## Description
Updated CNF Developer instructions to support using the new CNF setup and cleanup commands. Noted how to stop automatic deployment of CNF.

## Issues:
Fixes: #133 


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [x] develop
     * [x] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [x] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
