### PR TITLE
Adds CoreDNS as an example CNF

### DIFF
--- a/example-cnfs/coredns/README.md
+++ b/example-cnfs/coredns/README.md
@@ -1,0 +1,39 @@
+# Set up Sample CoreDNS CNF
+./sample-cnfs/sample-coredns-cnf/readme.md
+# Prerequistes
+### Install helm
+```
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+```
+### Optional: Use a helm version manager
+https://github.com/yuya-takeyama/helmenv
+Check out helmenv into any path (here is ${HOME}/.helmenv)
+```
+${HOME}/.helmenv)
+$ git clone https://github.com/yuya-takeyama/helmenv.git ~/.helmenv
+```
+Add ~/.helmenv/bin to your $PATH any way you like
+```
+$ echo 'export PATH="$HOME/.helmenv/bin:$PATH"' >> ~/.bash_profile
+```
+```
+helmenv versions 
+helmenv install <version 3.1?>
+```
+
+### core-dns installation
+```
+helm install coredns stable/coredns
+```
+### Pull down the helm chart code, untar it, and put it in the cnfs/coredns directory
+```
+helm pull stable/coredns
+```
+### Example cnf-conformance config file for sample-core-dns-cnf
+In ./cnfs/sample-core-dns-cnf/cnf-conformance.yml
+```
+---
+container_names: [coredns-coredns] 
+```

--- a/example-cnfs/coredns/README.md
+++ b/example-cnfs/coredns/README.md
@@ -1,39 +1,37 @@
-# Set up Sample CoreDNS CNF
-./sample-cnfs/sample-coredns-cnf/readme.md
+# What is [CoreDNS](https://coredns.io/)
+
+CoreDNS is a DNS server/forwarder, written in Go, that chains plugins. Each plugin performs a (DNS) function.
+
+DNS is a critical network function that can be found in many Telecom use cases such as the vCPE.
+
+CoreDNS can listen for DNS requests coming in over UDP/TCP, TLS (RFC 7858), also called DoT, DNS over HTTP/2 - DoH - (RFC 8484) and gRPC (not a standard).
+
+
 # Prerequistes
-### Install helm
+Follow [Pre-req steps](https://github.com/cncf/cnf-conformance/blob/master/INSTALL.md#prerequisites), including
+- Set the KUBECONFIG environment to point to the remote K8s cluster
+- Downloading the binary cnf-conformance release
+
+### Automated CNF installation
+
+Initialize the conformance suite
 ```
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-chmod 700 get_helm.sh
-./get_helm.sh
-```
-### Optional: Use a helm version manager
-https://github.com/yuya-takeyama/helmenv
-Check out helmenv into any path (here is ${HOME}/.helmenv)
-```
-${HOME}/.helmenv)
-$ git clone https://github.com/yuya-takeyama/helmenv.git ~/.helmenv
-```
-Add ~/.helmenv/bin to your $PATH any way you like
-```
-$ echo 'export PATH="$HOME/.helmenv/bin:$PATH"' >> ~/.bash_profile
-```
-```
-helmenv versions 
-helmenv install <version 3.1?>
+crystal src/cnf-conformance.cr setup
 ```
 
-### core-dns installation
+Configure and deploy CoreDNS as the target CNF
 ```
-helm install coredns stable/coredns
+crystal src/cnf-conformance.cr cnf_setup cnf-path=example-cnfs/coredns
 ```
-### Pull down the helm chart code, untar it, and put it in the cnfs/coredns directory
+
+Run the all the tests
 ```
-helm pull stable/coredns
+crystal src/cnf-conformance.cr all
 ```
-### Example cnf-conformance config file for sample-core-dns-cnf
-In ./cnfs/sample-core-dns-cnf/cnf-conformance.yml
+
+Check the results file
+
+Cleanup the cnf test setup (including undeployment of CoreDNS)
 ```
----
-container_names: [coredns-coredns] 
+crystal src/cnf-conformance.cr cnf_cleanup cnf-path=example-cnfs/coredns
 ```

--- a/example-cnfs/coredns/cnf-conformance.yml
+++ b/example-cnfs/coredns/cnf-conformance.yml
@@ -1,0 +1,15 @@
+---
+helm_directory: cnfs/coredns/helm_chart/coredns
+# helm_directory: helm_chart
+git_clone_url: 
+install_script: 
+release_name: coredns
+deployment_name: coredns-coredns 
+application_deployment_names: [coredns-coredns]
+helm_repository:
+  name: stable 
+  repo_url: https://kubernetes-charts.storage.googleapis.com
+helm_chart: stable/coredns
+helm_chart_container_name: coredns
+rolling_update_tag: 1.6.7
+white_list_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]


### PR DESCRIPTION
# CoreDNS as example CNF

## Description:

Adds CoreDNS as an example CNF with working cnf-conformance.yml and README on usage and description.

## Issues:
- #183 