### PR TITLE
Using unicode ⎯➤ instead of emoji arrow in published helm chart test

### DIFF
--- a/src/tasks/installability.cr
+++ b/src/tasks/installability.cr
@@ -101,12 +101,19 @@ task "helm_chart_published", ["helm_local_install"] do |_, args|
     puts "helm_chart_published args.raw: #{args.raw}" if check_verbose(args)
     puts "helm_chart_published args.named: #{args.named}" if check_verbose(args)
 
+    emoji_helm_chart_published="📊⎯➤🌐"
+
    if helm_repo_add 
+     # TODO: add message for successfully adding repo if verbose
      upsert_passed_task("helm_chart_published")
-     puts "PASSED: Published Helm Chart Repo added".colorize(:green)
+     # TODO: check for helm chart on repo
+     puts "✔️  PASSED: Published Helm Chart #{emoji_helm_chart_published}".colorize(:green)
    else
      upsert_failed_task("helm_chart_published")
-     puts "FAILURE: Published Helm Chart Repo failed to add".colorize(:red)
+     # TODO: add message for failing to add repo if verbose on
+     # TODO: skip check for helm chart on repo if repo could not be added
+     # TODO: check for helm chart on repo
+     puts "✖️  FAILURE: Published Helm Chart #{emoji_helm_chart_published}".colorize(:red)
    end
   rescue ex
     puts ex.message


### PR DESCRIPTION
- final emoji 📊⎯➤🌐
- switch to unicde line and error instead of emoji right arrow
  - Unicode Character “⎯” (U+23AF)
  - Unicode Character “➤” (U+27A4)
- added space before status emoji and PASSED or FAILED

# CNF Conformance PR Template

## Description
(name of issue/change)

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
