### PR TITLE
nodeport_not_used test now available #165 documentation

### DIFF
--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -39,7 +39,7 @@ The CNF Conformance program enables interoperability of CNFs from multiple vendo
 #### Configuration and lifecycle should be managed in a declarative manner, using [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/), [Operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/), or other [declarative interfaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#understanding-kubernetes-objects).  The Conformance suite checks this by:
 
 *  Testing if the CNF is installed using a [versioned](https://helm.sh/docs/topics/chart_best_practices/dependencies/#versions) Helm v3 chart
-*  Searching for hardcoded IP addresses or subnets in the configuration
+*  Searching for hardcoded IP addresses, subnets, or node ports in the configuration
 *  Checking for a liveness entry in the helm chart and if the container is responsive to it after a reset (e.g. by checking the [helm chart entry](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
 *  Checking for a readiness entry in the helm chart and if the container is responsive to it after a reset
 *  Checking if the pod/container can be started without mounting a volume (e.g. using [helm configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/)) that has configuration files

--- a/USAGE.md
+++ b/USAGE.md
@@ -151,6 +151,10 @@ crystal src/cnf-conformance.cr versioned_helm_chart
 ```
 crystal src/cnf-conformance.cr ip_addresses
 ```
+#### :heavy_check_mark: To test if there are node ports used in the service configuration
+```
+crystal src/cnf-conformance.cr nodepost_not_used
+```
 #### (PoC) To test if there is a liveness entry in the Helm chart
 ```
 crystal src/cnf-conformance.cr liveness

--- a/USAGE.md
+++ b/USAGE.md
@@ -153,7 +153,7 @@ crystal src/cnf-conformance.cr ip_addresses
 ```
 #### :heavy_check_mark: To test if there are node ports used in the service configuration
 ```
-crystal src/cnf-conformance.cr nodepost_not_used
+crystal src/cnf-conformance.cr nodeport_not_used
 ```
 #### (PoC) To test if there is a liveness entry in the Helm chart
 ```


### PR DESCRIPTION
# Microservice Documentation/Helm Deploy/NodePort
## Description
nodeport_not_used test now available

## Issues:
Refs: ##165

## How has this been tested:
 - [x] Covered by existing integration testing
 - [] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [x] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [x] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
