### PR TITLE
remove develop CI tests as `develop` is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CNF Conformance
-| Master | Develop |
-|---|---|
-|[![Build Status](https://www.travis-ci.org/cncf/cnf-conformance.svg?branch=master)](https://www.travis-ci.org/cncf/cnf-conformance)|[![Build Status](https://www.travis-ci.org/cncf/cnf-conformance.svg?branch=develop)](https://www.travis-ci.org/cncf/cnf-conformance)|
+| Master | 
+|---|
+|[![Build Status](https://www.travis-ci.org/cncf/cnf-conformance.svg?branch=master)](https://www.travis-ci.org/cncf/cnf-conformance)|
 
 The CNF Conformance program enables interoperability of Cloud native Network Functions (CNFs) from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to demonstrate conformance and implementation of best practices for both open and closed source Cloud native Network Functions. 
 


### PR DESCRIPTION
Removing `develop` CI test badge