### PR TITLE
#221 helm_deploy now uses a prefix for testing the deployment

### DIFF
--- a/src/tasks/installability.cr
+++ b/src/tasks/installability.cr
@@ -11,6 +11,7 @@ end
 desc "Will the CNF install using helm with helm_deploy?"
 task "helm_deploy" do |_, args|
   begin
+    release_name_prefix = "helm-deploy-"
     puts "helm_deploy" if check_verbose(args)
     config = get_parsed_cnf_conformance_yml(args)
 
@@ -27,9 +28,11 @@ task "helm_deploy" do |_, args|
     if helm_chart.empty? 
       #TODO make this work off of a helm directory if helm_directory was passed
       yml_file_path = cnf_conformance_yml_file_path(args)
-      helm_install = `#{helm} install #{release_name} #{yml_file_path}/#{helm_directory}`
+      puts "#{helm} install #{release_name_prefix}#{release_name} #{yml_file_path}/#{helm_directory}" if check_verbose(args)
+      helm_install = `#{helm} install #{release_name_prefix}#{release_name} #{yml_file_path}/#{helm_directory}`
     else 
-      helm_install = `#{helm} install #{release_name} #{helm_chart}`
+      puts "#{helm} install #{release_name_prefix}#{release_name} #{helm_chart}" if check_verbose(args)
+      helm_install = `#{helm} install #{release_name_prefix}#{release_name} #{helm_chart}`
     end 
 
     is_helm_installed = $?.success?
@@ -47,6 +50,9 @@ task "helm_deploy" do |_, args|
     ex.backtrace.each do |x|
       puts x
     end
+  ensure
+    puts "#{helm} uninstall #{release_name_prefix}#{release_name}" if check_verbose(args)
+    helm_uninstall = `#{helm} uninstall #{release_name_prefix}#{release_name}`
   end
 end
 


### PR DESCRIPTION
# #221 helm_deploy now uses a prefix for testing the deployment

## Description
#221 helm_deploy now uses a prefix for testing the deployment

## Issues:
Refs: #NNN

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [d] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
