### PR TITLE
re: #201 add validate_config task

### DIFF
--- a/spec/fixtures/cnf-conformance-invalid-and-unmapped-keys.yml
+++ b/spec/fixtures/cnf-conformance-invalid-and-unmapped-keys.yml
@@ -1,0 +1,16 @@
+---
+# invalid because missing helm_chart key
+git_clone_url: 
+install_script: 
+release_name: coredns
+deployment_name: coredns-coredns 
+application_deployment_names: [coredns-coredns]
+helm_repository:
+  name: stable 
+  repo_url: https://kubernetes-charts.storage.googleapis.com
+  test_on_helm_repo:
+helm_chart: stable/coredns
+helm_chart_container_name: coredns
+rolling_update_tag: 1.6.7
+white_list_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]
+test_at_root:

--- a/src/tasks/installability.cr
+++ b/src/tasks/installability.cr
@@ -178,3 +178,13 @@ task "helm_chart_valid", ["helm_local_install"] do |_, args|
   end
 end
 
+task "validate_config" do |_, args|
+  yml = parsed_config_file(ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
+  valid, warning_output = validate_cnf_conformance_yml(yml)
+
+  if valid
+    puts "✔️ PASSED: CNF configuration validated 📋"
+  else
+    puts "❌ FAILURE: Critical Error with CNF Configuration. Please review USAGE.md for steps to set up a valid CNF configuration file 📋"
+  end
+end


### PR DESCRIPTION
usage

```
 crystal src/cnf-conformance.cr validate_config cnf-config=./spec/fixtures/cnf-conformance-unmapped-keys.yml

```

# CNF Conformance PR Template

## Description
(name of issue/change)

## Issues:
Refs: #201

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
