### PR TITLE
Update regexp used by kubectl_version function

### DIFF
--- a/spec/utils/system_information/curl_spec.cr
+++ b/spec/utils/system_information/curl_spec.cr
@@ -6,7 +6,7 @@ require "../../../src/tasks/utils/system_information/curl.cr"
 require "file_utils"
 require "sam"
 
-describe "Helm" do
+describe "Curl" do
 
   it "'curl_global_response()' should return the information about the curl installation", tags: "happy-path"  do
     (curl_global_response(true)).should contain("curl")

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -6,7 +6,7 @@ require "../../../src/tasks/utils/system_information/kubectl.cr"
 require "file_utils"
 require "sam"
 
-describe "Helm" do
+describe "Kubectl" do
 
   it "'kubectl_global_response()' should return the information about the kubectl installation", tags: "happy-path"  do
     (kubectl_global_response(true)).should contain("Client Version")
@@ -17,7 +17,7 @@ describe "Helm" do
   end
 
   it "'kubectl_version()' should return the information about the kubectl version", tags: "happy-path"  do
-    (kubectl_version(kubectl_global_response)).should match(/(([0-9]{1,3}[\.]){1,2}[0-9]{1,3})/)
+    (kubectl_version(kubectl_global_response)).should match(/(([0-9]{1,3}[\.]){1,2}[0-9]{1,3}[+]?)/)
     (kubectl_version(kubectl_local_response)).should contain("")
   end
 

--- a/spec/utils/system_information/wget_spec.cr
+++ b/spec/utils/system_information/wget_spec.cr
@@ -6,7 +6,7 @@ require "../../../src/tasks/utils/system_information/wget.cr"
 require "file_utils"
 require "sam"
 
-describe "Helm" do
+describe "Wget" do
 
   it "'wget_global_response()' should return the information about the wget installation", tags: "happy-path"  do
     (wget_global_response(true)).should contain("GNU Wget")

--- a/src/tasks/utils/system_information/kubectl.cr
+++ b/src/tasks/utils/system_information/kubectl.cr
@@ -81,7 +81,7 @@ end
 def kubectl_version(kubectl_response, verbose=false)
   # example
   # Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:13:54Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"} 
-  resp = kubectl_response.match /Client Version: version.Info{(Major:"(([0-9]{1,3})"\, )Minor:"([0-9]{1,3})")/
+  resp = kubectl_response.match /Client Version: version.Info{(Major:"(([0-9]{1,3})"\, )Minor:"([0-9]{1,3}[+]?)")/
   puts resp if verbose
   if resp
     "#{resp && resp.not_nil![3]}.#{resp && resp.not_nil![4]}"


### PR DESCRIPTION
## Description
Kubectl client version can contains non-numeric symbols in its minor version. E. g.:
```
Client Version: version.Info{Major:"1", Minor:"16+", GitVersion:"v1.16.6-beta.0", GitCommit:"e7f962ba86f4ce7033828210ca3556393c377bcc", GitTreeState:"clean", BuildDate:"2020-01-15T08:26:26Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-30T20:19:45Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
```
This exception causes that the regex used to discover information fails. This change addresses that scenario.

## Issues:
NA

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
