### PR TITLE
#239 updated shard.yml to ensure correct version of crystal is used

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ targets:
   cnf_conformance:
     main: src/cnf_conformance.cr
 
-crystal: 0.31.1
+crystal: 0.33.0
 
 dependencies:
   sam:


### PR DESCRIPTION
# CNF Conformance PR

## Description
shard.yml was declaring 0.31.1 as the crystal version, but it was changed to the proper version - 0.33.0

## Issues:
Refs: #239 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
