### PR TITLE
need kube-multus whitelisted because beta test clusters have multus i…

### DIFF
--- a/example-cnfs/coredns/cnf-conformance.yml
+++ b/example-cnfs/coredns/cnf-conformance.yml
@@ -14,4 +14,4 @@ helm_repository:
 helm_chart: stable/coredns
 helm_chart_container_name: coredns
 rolling_update_tag: 1.6.7
-white_list_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]
+white_list_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy, kube-multus]


### PR DESCRIPTION
## Whitelisting kube-multus in CoreDNS example

Some clusters have Multus installed and kube-multus will need to be whitelisted. This is the case in the beta test clusters.

Ref: #238 #232