### PR TITLE
Deployment wait output to make defaults quieter

### DIFF
--- a/src/tasks/utils/sample_utils.cr
+++ b/src/tasks/utils/sample_utils.cr
@@ -48,13 +48,13 @@ def wait_for_install(deployment_name, wait_count=180, namespace="default")
   second_count = 0
   all_deployments = `kubectl get deployments --namespace=#{namespace}`
   current_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
-  puts all_deployments
+  LOGGING.info(all_deployments)
   until (current_replicas.empty? != true && current_replicas.to_i > 0) || second_count > wait_count.to_i
-    puts "second_count = #{second_count}"
+    LOGGING.info("second_count = #{second_count}")
     sleep 1
     all_deployments = `kubectl get deployments --namespace=#{namespace}`
     current_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
-    puts all_deployments
+    LOGGING.info(all_deployments)
     second_count = second_count + 1 
   end
 end 


### PR DESCRIPTION
Updated deployment output to use logger so it can be turned off for in non-verbose modes (eg. INFO and DEBUG).