### PR TITLE
Update how and when results are saved so a repeated warning for overwriting results.yml does not occur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swo
 /cnfs
 /tools
+/results
 admin.conf
 cnf-conformance
 results.yml

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -13,22 +13,16 @@ describe "Utils" do
     `./cnf-conformance results_yml_cleanup`
   end
 
-  it "'create_results_yml' should create a results yaml file"  do
-    create_results_yml
+  it "'#Results.file' should return the name of the current yaml file"  do
+    clean_results_yml
     yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     (yaml["name"]).should eq("cnf conformance")
   end
 
-  it "'final_cnf_results_yml' should return the named yaml file"  do
-    yml_name = create_final_results_yml_name
-    unless File.exists?(yml_name)
-      File.open(yml_name, "w") do |f| 
-        YAML.dump(template_results_yml, f)
-      end 
-    end
-    (final_cnf_results_yml).should eq(yml_name)
+  it "'final_cnf_results_yml' should return the latest time stamped results file"  do
+    (final_cnf_results_yml).should contain("cnf-conformance-results")
   end
 
   it "'points_yml' should parse and return the points yaml file"  do
@@ -50,7 +44,7 @@ describe "Utils" do
   end
 
   it "'failed_task' should find and update an existing task in the file"  do
-    create_results_yml
+    clean_results_yml
     failed_task("liveness", "FAILURE: No livenessProbe found")
 
     yaml = File.open("#{Results.file}") do |file|
@@ -61,7 +55,7 @@ describe "Utils" do
   end
 
   it "'passed_task' should find and update an existing task in the file"  do
-    create_results_yml
+    clean_results_yml
     passed_task("liveness", "PASSED: livenessProbe found")
 
     yaml = File.open("#{Results.file}") do |file|
@@ -72,18 +66,18 @@ describe "Utils" do
   end
 
   it "'task_required' should return if the passed task is required"  do
-    create_results_yml
+    clean_results_yml
     (task_required("privileged")).should be_true
   end
 
   it "'failed_required_tasks' should return a list of failed required tasks"  do
-    create_results_yml
+    clean_results_yml
     failed_task("privileged", "FAILURE: Privileged container found")
     (failed_required_tasks).should eq(["privileged"])
   end
 
   it "'upsert_task' insert task in the results file"  do
-    create_results_yml
+    clean_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
@@ -93,7 +87,7 @@ describe "Utils" do
   end
 
   it "'upsert_task' should find and update an existing task in the file"  do
-    create_results_yml
+    clean_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     upsert_task("liveness", PASSED, task_points("liveness"))
     yaml = File.open("#{Results.file}") do |file|
@@ -105,29 +99,29 @@ describe "Utils" do
   end
 
   it "'total_points' should sum the total amount of points in the results" do
-    create_results_yml
+    clean_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     (total_points).should eq(5)
   end
 
   it "'tasks_by_tag' should return the tasks assigned to a tag" do
-    create_results_yml
+    clean_results_yml
     (tasks_by_tag("configuration_lifecycle")).should eq(["ip_addresses", "liveness", "readiness", "rolling_update", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration"])
     (tasks_by_tag("does-not-exist")).should eq([] of YAML::Any) 
   end
 
   it "'all_task_test_names' should return all tasks names" do
-    create_results_yml
+    clean_results_yml
     (all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "ip_addresses", "liveness", "readiness", "rolling_update", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found"])
   end
 
   it "'all_result_test_names' should return the tasks assigned to a tag" do
-    create_results_yml
+    clean_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     (all_result_test_names(Results.file)).should eq(["liveness"])
   end
   it "'results_by_tag' should return a list of results by tag" do
-    create_results_yml
+    clean_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     (results_by_tag("configuration_lifecycle")).should eq([{"name" => "liveness", "status" => "passed", "points" => 5}])
     (results_by_tag("does-not-exist")).should eq([] of YAML::Any) 

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -15,7 +15,7 @@ describe "Utils" do
 
   it "'create_results_yml' should create a results yaml file"  do
     create_results_yml
-    yaml = File.open("#{LOGFILE}") do |file|
+    yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     (yaml["name"]).should eq("cnf conformance")
@@ -53,7 +53,7 @@ describe "Utils" do
     create_results_yml
     failed_task("liveness", "FAILURE: No livenessProbe found")
 
-    yaml = File.open("#{LOGFILE}") do |file|
+    yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     puts yaml.inspect
@@ -64,7 +64,7 @@ describe "Utils" do
     create_results_yml
     passed_task("liveness", "PASSED: livenessProbe found")
 
-    yaml = File.open("#{LOGFILE}") do |file|
+    yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     puts yaml.inspect
@@ -85,7 +85,7 @@ describe "Utils" do
   it "'upsert_task' insert task in the results file"  do
     create_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
-    yaml = File.open("#{LOGFILE}") do |file|
+    yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     # puts yaml["items"].as_a.inspect
@@ -96,7 +96,7 @@ describe "Utils" do
     create_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
     upsert_task("liveness", PASSED, task_points("liveness"))
-    yaml = File.open("#{LOGFILE}") do |file|
+    yaml = File.open("#{Results.file}") do |file|
       YAML.parse(file)
     end
     # puts yaml["items"].as_a.inspect
@@ -124,7 +124,7 @@ describe "Utils" do
   it "'all_result_test_names' should return the tasks assigned to a tag" do
     create_results_yml
     upsert_task("liveness", PASSED, task_points("liveness"))
-    (all_result_test_names(LOGFILE)).should eq(["liveness"])
+    (all_result_test_names(Results.file)).should eq(["liveness"])
   end
   it "'results_by_tag' should return a list of results by tag" do
     create_results_yml

--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -1,6 +1,7 @@
 require "sam"
 require "./tasks/**"
 
+
 desc "The CNF Conformance program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
 task "all", ["all_prereqs", "configuration_file_setup", "compatibility","statelessness", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_affinity", "microservice", "resilience"] do  |_, args|
   puts "all" if check_verbose(args)
@@ -17,9 +18,9 @@ task "all", ["all_prereqs", "configuration_file_setup", "compatibility","statele
     puts "Failed required tasks: #{failed_required_tasks.inspect}".colorize(:red)
   end
 
-  new_results = create_final_results_yml_name
-  results = `mv #{LOGFILE} #{new_results}`
-  puts "Results have been saved to #{new_results}"
+  # new_results = create_final_results_yml_name
+  # results = `mv #{LOGFILE} #{new_results}`
+  puts "Results have been saved to #{Results.file}"
 end
 
 task "all_prereqs" do |_, args|

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -35,8 +35,8 @@ task "cleanup_all", ["cleanup_samples", "tools_cleanup"] do  |_, args|
 end
 
 task "results_yml_cleanup" do |_, args|
-  if File.exists?("#{LOGFILE}")
-    rm = `rm #{LOGFILE}`
+  if File.exists?("#{Results.file}")
+    rm = `rm #{Results.file}`
     puts rm if check_verbose(args)
   end
 end

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -11,6 +11,5 @@ end
 task "configuration_file_setup" do |_, args|
   puts "configuration_file_setup" if check_verbose(args)
   create_points_yml
-  create_results_yml
 end
 

--- a/src/tasks/utils/sample_utils.cr
+++ b/src/tasks/utils/sample_utils.cr
@@ -8,7 +8,7 @@ require "./types/cnf_conformance_yml_type.cr"
 # TODO put this in a module
 
 def final_cnf_results_yml
-  results_file = `find ./* -name "cnf-conformance-results-*.yml"`.split("\n")[-2].gsub("./", "")
+  results_file = `find ./results/* -name "cnf-conformance-results-*.yml"`.split("\n")[-2].gsub("./", "")
   if results_file.empty?
     raise "No cnf_conformance-results-*.yml found! Did you run the all task?"
   end

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -3,7 +3,13 @@ require "colorize"
 require "./sample_utils.cr"
 require "logger"
 
-
+class Results
+  @@file : String
+  @@file = create_final_results_yml_name
+  def self.file
+    @@file
+  end
+end
 
 # TODO make constants local or always retrieve from environment variables
 # TODO Move constants out
@@ -13,8 +19,8 @@ CNF_DIR = "cnfs"
 CONFIG_FILE = "cnf-conformance.yml"
 TOOLS_DIR = "tools"
 BASE_CONFIG = "./config.yml"
-# LOGFILE = "cnf-conformance-results-#{Time.utc.to_s("%Y%m%d")}.log"
-LOGFILE = "results.yml"
+# Results.file = "cnf-conformance-results-#{Time.utc.to_s("%Y%m%d")}.log"
+# Results.file = "results.yml"
 POINTSFILE = "points.yml"
 PASSED = "passed"
 FAILED = "failed"
@@ -32,6 +38,8 @@ LOGGING.formatter = Logger::Formatter.new do |severity, datetime, progname, mess
 	io << label[0] << ", [" << datetime << " #" << Process.pid << "] "
 	io << label.rjust(5) << " -- " << progname << ": " << message
 end
+
+
 
 def loglevel
   toggle_on = false
@@ -220,9 +228,9 @@ end
 def create_results_yml(verbose=false)
   puts "create_results_yml"
   continue = false
-  puts "file exists?:#{File.exists?(LOGFILE)}"
-  if File.exists?("#{LOGFILE}")
-    puts "Do you wish to overwrite the #{LOGFILE} file? If so, your previous results.yml will be lost."
+  puts "file exists?:#{File.exists?(Results.file)}"
+  if File.exists?("#{Results.file}")
+    puts "Do you wish to overwrite the #{Results.file} file? If so, your previous results.yml will be lost."
     print "(Y/N) (Default N): > "
     if ENV["CRYSTAL_ENV"]? == "TEST"
       continue = true
@@ -236,7 +244,7 @@ def create_results_yml(verbose=false)
     continue = true
   end
   if continue
-    File.open("#{LOGFILE}", "w") do |f| 
+    File.open("#{Results.file}", "w") do |f| 
       YAML.dump(template_results_yml, f)
     end 
   end
@@ -252,7 +260,7 @@ def points_yml
 end
 
 def upsert_task(task, status, points)
-  results = File.open("#{LOGFILE}") do |f| 
+  results = File.open("#{Results.file}") do |f| 
     YAML.parse(f)
   end 
 
@@ -263,7 +271,7 @@ def upsert_task(task, status, points)
   end
 
   result_items << YAML.parse "{name: #{task}, status: #{status}, points: #{points}}"
-  File.open("#{LOGFILE}", "w") do |f| 
+  File.open("#{Results.file}", "w") do |f| 
     YAML.dump({name: results["name"],
                status: results["status"],
                points: results["points"],
@@ -328,7 +336,7 @@ def task_required(task)
 end
 
 def failed_required_tasks
-  yaml = File.open("#{LOGFILE}") do |file|
+  yaml = File.open("#{Results.file}") do |file|
     YAML.parse(file)
   end
   yaml["items"].as_a.reduce([] of String) do |acc, i|
@@ -343,7 +351,7 @@ def failed_required_tasks
 end
 
 # def total_points
-#   yaml = File.open("#{LOGFILE}") do |file|
+#   yaml = File.open("#{Results.file}") do |file|
 #     YAML.parse(file)
 #   end
 #   yaml["items"].as_a.reduce(0) do |acc, i|
@@ -361,7 +369,7 @@ def total_points(tag=nil)
   else
     tasks = all_task_test_names
   end
-  yaml = File.open("#{LOGFILE}") do |file|
+  yaml = File.open("#{Results.file}") do |file|
     YAML.parse(file)
   end
   yaml["items"].as_a.reduce(0) do |acc, i|
@@ -424,7 +432,7 @@ end
 def results_by_tag(tag)
   task_list = tasks_by_tag(tag)
 
-  results = File.open("#{LOGFILE}") do |f| 
+  results = File.open("#{Results.file}") do |f| 
     YAML.parse(f)
   end 
 


### PR DESCRIPTION
# Update how and when results are saved so a repeated warning for overwriting results.yml does not occur

## Description
Update how and when results are saved so a repeated warning for overwriting results.yml does not occur

## Issues:
Refs: #282

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [x] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
