### PR TITLE
Fix docker image size check

### DIFF
--- a/src/tasks/microservice.cr
+++ b/src/tasks/microservice.cr
@@ -111,11 +111,11 @@ task "reasonable_image_size", ["retrieve_manifest"] do |_, args|
 
     LOGGING.info "micro_size: #{micro_size.to_s}" if check_verbose(args)
 
-    # if a sucessfull call and size of container is less than 5gb
+    # if a sucessfull call and size of container is less than 5gb (5 billion bytes)
     if docker_repository && 
         docker_resp &&
         docker_resp.status_code == 200 && 
-        micro_size.to_s.to_i64 < 50000000
+        micro_size.to_s.to_i64 < 5_000_000_000
       upsert_passed_task("reasonable_image_size", "✔️  PASSED: Image size is good")
     else
       upsert_failed_task("reasonable_image_size", "✖️  FAILURE: Image size too large")


### PR DESCRIPTION
# Fix docker image size check

## Description
Since full size of an image is retrieved in bytes, then `50 000 000` is only 50mb, but the comment says it should be less than 5gb.

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
