### PR TITLE
Maint/upgrade crystal to 0.35.1 logging refactor

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ _NOTE: Does not handle manually deployed CNFs_
 # Source Install
 
 ## Installation
-  * Install [crystal-lang](https://crystal-lang.org/install/) version 0.34.0
+  * Install [crystal-lang](https://crystal-lang.org/install/) version 0.35.1
   * Install the project's crystal dependencies
   ```
   shards install

--- a/sam.cr
+++ b/sam.cr
@@ -1,9 +1,0 @@
-require "sam"
-
-# Here you can define your tasks
-# desc "with description to be used by help command"
-task "test" do
-  puts "ping"
-end
-
-Sam.help

--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -1,7 +1,6 @@
 require "totem"
 require "colorize"
 require "./sample_utils.cr"
-require "logger"
 require "halite"
 
 module ReleaseManager 


### PR DESCRIPTION
# CNF Conformance PR Template

## Description

(ab)uses method missings to move us off of `logger` and on to `log`

partial refactor to remove logger deprecation warnings ... …

though I don't really love it because it (ab)uses method_missing

so I make seperate pr

also it only buys us a little bit because several of our dependancies
are still using the deprecated logger ... so we don't even get rid of
all dep warnings

## Issues:
Refs: #311 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
