### PR TITLE
fixed latest_release URL

### DIFF
--- a/curl_install.sh
+++ b/curl_install.sh
@@ -32,7 +32,7 @@ get_latest_release() {
 # Install CNF-Conformance
 LATEST_RELEASE=$(get_latest_release cncf/cnf-conformance)
 mkdir -p ~/.cnf-conformance
-curl -L https://github.com/cncf/cnf-conformance/releases/download/$LATEST_RELEASE/cnf-conformance.tar.gz -o ~/.cnf-conformance/cnf-conformance.tar.gz
+curl -L https://github.com/cncf/cnf-conformance/releases/download/$LATEST_RELEASE/cnf-conformance-$LATEST_RELEASE.tar.gz -o ~/.cnf-conformance/cnf-conformance.tar.gz
 tar -C ~/.cnf-conformance -xvf ~/.cnf-conformance/cnf-conformance.tar.gz
 rm ~/.cnf-conformance/cnf-conformance.tar.gz
 


### PR DESCRIPTION
- LATEST_RELEASE is part of the tar.gz package URL

# CNF Conformance PR Template

## Description
URL missing latest release for the tar.gz package

## Issues:
Refs: #324 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [x] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
