### PR TITLE
Fix chaos-mesh version through constant and update repository URL

### DIFF
--- a/src/tasks/resilience.cr
+++ b/src/tasks/resilience.cr
@@ -4,6 +4,8 @@ require "colorize"
 require "crinja"
 require "./utils/utils.cr"
 
+CHAOS_MESH_VERSION = "v0.8.0"
+
 desc "The CNF conformance suite checks to see if the CNFs are resilient to failures."
 task "resilience", ["chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill" ] do |t, args|
   VERBOSE_LOGGING.info "resilience" if check_verbose(args)
@@ -17,12 +19,12 @@ task "install_chaosmesh" do |_, args|
   VERBOSE_LOGGING.info "install_chaosmesh" if check_verbose(args)
   current_dir = FileUtils.pwd 
   helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
-  crd_install = `kubectl create -f https://raw.githubusercontent.com/pingcap/chaos-mesh/v0.8.0/manifests/crd.yaml`
+  crd_install = `kubectl create -f https://raw.githubusercontent.com/chaos-mesh/chaos-mesh/#{CHAOS_MESH_VERSION}/manifests/crd.yaml`
   VERBOSE_LOGGING.info "#{crd_install}" if check_verbose(args)
   unless Dir.exists?("#{current_dir}/#{TOOLS_DIR}/chaos_mesh")
     # TODO use a tagged version
-    fetch_chaos_mesh = `git clone https://github.com/pingcap/chaos-mesh.git #{current_dir}/#{TOOLS_DIR}/chaos_mesh`
-    checkout_tag = `cd #{current_dir}/#{TOOLS_DIR}/chaos_mesh && git checkout tags/v0.8.0 && cd -`
+    fetch_chaos_mesh = `git clone https://github.com/chaos-mesh/chaos-mesh.git #{current_dir}/#{TOOLS_DIR}/chaos_mesh`
+    checkout_tag = `cd #{current_dir}/#{TOOLS_DIR}/chaos_mesh && git checkout tags/#{CHAOS_MESH_VERSION} && cd -`
   end
   install_chaos_mesh = `#{helm} install chaos-mesh #{current_dir}/#{TOOLS_DIR}/chaos_mesh/helm/chaos-mesh --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`
   wait_for_resource("#{current_dir}/spec/fixtures/chaos_network_loss.yml")
@@ -35,7 +37,7 @@ task "uninstall_chaosmesh" do |_, args|
   VERBOSE_LOGGING.info "uninstall_chaosmesh" if check_verbose(args)
   current_dir = FileUtils.pwd
   helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
-  crd_delete = `kubectl delete -f https://raw.githubusercontent.com/pingcap/chaos-mesh/master/manifests/crd.yaml`
+  crd_delete = `kubectl delete -f https://raw.githubusercontent.com/chaos-mesh/chaos-mesh/#{CHAOS_MESH_VERSION}/manifests/crd.yaml`
   FileUtils.rm_rf("#{current_dir}/#{TOOLS_DIR}/chaos_mesh")
   delete_chaos_mesh = `#{helm} delete chaos-mesh`
 end


### PR DESCRIPTION
## Description
Because chaos-mesh is now a CNCF sandbox project with its own domain, the CRD of chaos-mesh have been changed ([in this commit](https://github.com/chaos-mesh/chaos-mesh/commit/26ec8ddc5a65566b8160852280b30bdbf1cb6895),
As a result, we have an inconcistency in the `resilience.cr` file, where we install `chaos-mesh` version `v0.8.0`, but we uninstall the latest version of the chaos-mesh repository (master)

This commit simply updates the repository URL and fixes a consistent chaos-mesh version through a constant in the `resilience.cr` file.

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Bare-metal K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
