### PR TITLE
poc of tab_completion

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -68,7 +68,20 @@ crystal bin/ameba.cr
 crystal src/cnf-conformance.cr help 
 ```
 
+
+## Install Tab Completion
+
+NOTE: also compatible with the styles from kubectl completion install if you prefer
+https://kubernetes.io/docs/tasks/tools/install-kubectl/#enable-kubectl-autocompletion
+
+``` 
+./cnf-conformance completion -l error > test.sh
+source test.sh
+```
+
+
 ## Compatibility Tests
+
 #### :heavy_check_mark: To run all of the compatibility tests
 ```
 crystal src/cnf-conformance.cr compatibility

--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -51,4 +51,22 @@ task "test" do
   puts "ping"
 end
 
+# https://www.thegeekstuff.com/2013/12/bash-completion-complete/
+# https://kubernetes.io/docs/tasks/tools/install-kubectl/#enable-kubectl-autocompletion
+# https://stackoverflow.com/questions/43794270/disable-or-unset-specific-bash-completion
+desc "Install Shell Completion: check https://github.com/cncf/cnf-conformance/blob/master/USAGE.md for usage"
+task "completion" do |_|
+
+# assumes bash completion feel free to make a pr for zsh and check an arg for it
+bin_name = "cnf-conformance"
+
+completion_template = <<-TEMPLATE
+# to remove
+# complete -r #{bin_name}
+complete -W "#{Sam.root_namespace.all_tasks.map(&.name).join(" ")}" #{bin_name}
+TEMPLATE
+
+puts completion_template
+end
+
 Sam.help


### PR DESCRIPTION
also documentation

# CNF Conformance PR Template

## Description

implements tab completion. 

works wit the binary very well. that is `./cnf-conformance <TAB> <TAB>`

wish I could get it work with source  ie. `crystal src/cnf-conformance.cr <TAB> <TAB>`

but that is a whole can of worms that turns a 3 pter into an 8.

So we can just use the bin to get the names and copy pasta

## Issues:
Refs: #265 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
