### PR TITLE
make wait_for_install wait on all replicas

### DIFF
--- a/src/tasks/utils/sample_utils.cr
+++ b/src/tasks/utils/sample_utils.cr
@@ -48,9 +48,10 @@ end
 def wait_for_install(deployment_name, wait_count=180, namespace="default")
   second_count = 0
   all_deployments = `kubectl get deployments --namespace=#{namespace}`
+  desired_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.replicas}'`
   current_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
   LOGGING.info(all_deployments)
-  until (current_replicas.empty? != true && current_replicas.to_i > 0) || second_count > wait_count.to_i
+  until (current_replicas.empty? != true && current_replicas.to_i == desired_replicas.to_i) || second_count > wait_count.to_i
     LOGGING.info("second_count = #{second_count}")
     sleep 1
     all_deployments = `kubectl get deployments --namespace=#{namespace}`


### PR DESCRIPTION
## Description

Without this fix, wait_for_install waits for at least one replica to be ready. However for a deployment of a CNF with multiple replicas, we need to wait for all replicas to be in the ready state before declaring it 'installed'.
At least this is what is assumed by the `chaos_container_kill` test, which uses the `wait_for_install` method to check that after a pod is killed, a new one is spawned to match the number of desired replicas.
In the previous version of the function, when there are more than 1 replica (e.g. with the `envoy` example), the test does not wait and produces a wrong result.

## How has this been tested:
 - [ ] Test environment
    * [x] Bare-metal K8s cluster

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)

**Code Review**
- [ ] ⚠ Is it ok to make `wait_for_install` wait for all replicas to be ready ? what side effects could this have ?
