### PR TITLE
#362 release manager spec tests now disabled for pull requests 

### DIFF
--- a/spec/utils/release_manager_spec.cr
+++ b/spec/utils/release_manager_spec.cr
@@ -33,15 +33,23 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager::GithubReleaseManager.github_releases' should return the existing releases", tags: "release"  do
-    (ReleaseManager::GithubReleaseManager.github_releases.size).should be > 0
+    if ENV["GITHUB_USER"]?.nil?
+      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    else 
+      ((ReleaseManager::GithubReleaseManager.github_releases.size) > 0).should be_true
+    end
   end
 
   it "'#ReleaseManager::GithubReleaseManager.upsert_release' should return the upserted release and asset response", tags: "release"  do
-    found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
-    if asset
-      (asset["errors"]?==nil || (asset["errors"]? && asset["errors"][0]["code"]  == "already_exists")).should be_truthy
-    else
-      (asset).should_not be_nil
+    if ENV["GITHUB_USER"]?.nil?
+      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    else 
+      found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
+      if asset
+        (asset["errors"]?==nil || (asset["errors"]? && asset["errors"][0]["code"]  == "already_exists")).should be_truthy
+      else
+        (asset).should_not be_nil
+      end
     end
   end
 
@@ -51,9 +59,13 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager::GithubReleaseManager.delete_release' should delete the release from the found_id", tags: "release"  do
-    found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
-    resp_code = ReleaseManager::GithubReleaseManager.delete_release("test_version")
-    (resp_code == 204).should be_truthy
+    if ENV["GITHUB_USER"]?.nil?
+      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    else 
+      found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
+      resp_code = ReleaseManager::GithubReleaseManager.delete_release("test_version")
+      (resp_code == 204).should be_truthy
+    end
   end
   it "'#ReleaseManager.detached_head?' should return if the head is detached", tags: "release"  do
     (ReleaseManager.detached_head?).should_not be_nil
@@ -66,14 +78,22 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager.latest_release' should return latest release", tags: "release"  do
-    issues = ReleaseManager.latest_release
-    # https://github.com/semver/semver/blob/master/semver.md#is-v123-a-semantic-version
-    (issues.match(/^(.|)(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)).should_not be_nil
+    if ENV["GITHUB_USER"]?.nil?
+      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    else 
+      issues = ReleaseManager.latest_release
+      # https://github.com/semver/semver/blob/master/semver.md#is-v123-a-semantic-version
+      (issues.match(/^(.|)(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/)).should_not be_nil
+    end
   end
 
   it "'#ReleaseManager.issue_title' should return issue title", tags: "release"  do
-    issues = ReleaseManager.issue_title("#318")
-    (issues.match(/#206 documentation update/)).should_not be_nil
+    if ENV["GITHUB_USER"]?.nil?
+      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    else 
+      issues = ReleaseManager.issue_title("#318")
+      (issues.match(/#206 documentation update/)).should_not be_nil
+    end
   end
 
 end


### PR DESCRIPTION
#362 release manager now disabled for pull requests

## Description
#362 release manager now disabled for pull requests

## Issues:
Refs: #362

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
