### PR TITLE
#365 Add support for running platform tests without a workload cnf 

### DIFF
--- a/spec/platform/hardware_and_scheduler.cr
+++ b/spec/platform/hardware_and_scheduler.cr
@@ -10,8 +10,6 @@ describe "Platform" do
     $?.success?.should be_true
     `./cnf-conformance setup`
     $?.success?.should be_true
-    `./cnf-conformance sample_coredns_with_wait_setup`
-    $?.success?.should be_true
   end
   it "'oci_compliant' should pass if all runtimes are oci_compliant" do
       response_s = `./cnf-conformance platform:oci_compliant`

--- a/spec/platform/platform_spec.cr
+++ b/spec/platform/platform_spec.cr
@@ -12,6 +12,13 @@ describe "Platform" do
     `./cnf-conformance sample_coredns_with_wait_setup`
     $?.success?.should be_true
   end
+  it "'platform:*' should not error out when no cnf is installed" do
+    response_s = `./cnf-conformance cleanup`
+    response_s = `./cnf-conformance platform:oci_compliant`
+    LOGGING.info response_s
+    puts response_s
+    (/No cnf_conformance.yml found/ =~ response_s).should be_nil
+  end
   it "'k8s_conformance' should pass if the sonobuoy tests pass" do
     response_s = `./cnf-conformance k8s_conformance`
     LOGGING.info response_s

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -224,13 +224,16 @@ end
 
 # TODO give example for calling
 def all_cnfs_task_runner(args, &block : Sam::Args -> String | Colorize::Object(String) | Nil)
-  # LOGGING.info("all_cnfs_task_runner cnf_config_list: #{cnf_config_list.inspect}")
-  cnf_config_list.map do |x|
-    # LOGGING.info("all_cnfs_task_runner config_list x: #{x}")
-    new_args = Sam::Args.new(args.named, args.raw)
-    new_args.named["cnf-config"] = x
-    # LOGGING.info("all_cnfs_task_runner new_args: #{new_args.inspect}")
-    single_task_runner(new_args, &block)
+
+  # Platforms tests dont have any cnfs
+  if cnf_config_list(silent: true).size == 0
+    single_task_runner(args, &block)
+  else
+    cnf_config_list(silent: true).map do |x|
+      new_args = Sam::Args.new(args.named, args.raw)
+      new_args.named["cnf-config"] = x
+      single_task_runner(new_args, &block)
+    end
   end
 end
 


### PR DESCRIPTION

# Add support for running platform tests without a workload cnf 

## Description
Add support for running platform tests without a workload cnf 

## Issues:
Refs: ##365

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [x] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
