### PR TITLE
Specs now do not have the initial 3 warnings

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,7 +6,7 @@ ENV["CRYSTAL_ENV"] = "TEST"
 
 
 LOGGING.info "Building ./cnf-conformance".colorize(:green)
-`crystal build src/cnf-conformance.cr`
+`crystal build --warnings none src/cnf-conformance.cr`
 if $?.success?
   LOGGING.info "Build Success!".colorize(:green)
 else


### PR DESCRIPTION
# Specs now do not have the initial 3 warnings

## Description
Specs now do not have the initial 3 warnings

## Issues:

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
