### PR TITLE
#348 release date now has command behind day

### DIFF
--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -94,7 +94,7 @@ TEMPLATE
         json = { "tag_name" => upsert_version, 
                  "draft" => draft, 
                  "prerelease" => prerelease, 
-                 "name" => "#{upsert_version} #{Time.local.to_s("%B, %d %Y")}", 
+                 "name" => "#{upsert_version} #{Time.local.to_s("%B %d, %Y")}", 
                  "body" => notes_template }
 
         LOGGING.info "Release not found.  Creating a release: # url: #{release_url} headers: #{headers} json #{json}"
@@ -111,7 +111,7 @@ TEMPLATE
               json: { "tag_name" => upsert_version,
                       "draft" => draft,
                       "prerelease" => prerelease,
-                      "name" => "#{upsert_version} #{Time.local.to_s("%B, %d %Y")}",
+                      "name" => "#{upsert_version} #{Time.local.to_s("%B %d, %Y")}",
                       "body" => notes_template })
       found_release = JSON.parse(found_resp.body)
 


### PR DESCRIPTION
# #348 release date now has command behind day

## Description
#348 release date now has command behind day

## Issues:
Refs: #348

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
