### PR TITLE
CNF without guaranteed QOS can disrupt other CNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The CNF Conformance Test Suite will inspect CNFs for the following characteristi
 - **Installable and Upgradeable** - CNFs should use standard, in-band deployment tools such as Helm (version 3) charts.
 - **Hardware Resources and Scheduling** - The CNF container should access all hardware and schedule to specific worker nodes by using a device plugin.
 - **Resilience** - CNFs should be resilient to failures inevitable in cloud environments. CNF Resilience should be tested to ensure CNFs are designed to deal with non-carrier-grade shared cloud HW/SW platform.
+- **Optimal Resource Allocation** - CNFs should use integer resources and guranteed QOS class type whenever possible to avoid resource contention  
+
 
 See the [Conformance Test Categories Documentation](https://github.com/cncf/cnf-conformance/blob/master/TEST-CATEGORIES.md) for a complete overview of the tests.
 


### PR DESCRIPTION
## Description

A CNF without a Guaranteed QOS class can disrupt other running CNFs on the same nodes as they can both share the same resources.
 Requests and Limits of CNF should match and should be an integer number.


See https://github.com/cncf/cnf-conformance/pull/450#issuecomment-720748885

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
