### PR TITLE
#328 cluster api now has a negative test

### DIFF
--- a/spec/platform/cluster_api_spec.cr
+++ b/spec/platform/cluster_api_spec.cr
@@ -24,6 +24,7 @@ describe "Cluster API" do
       (/Cluster API is enabled/ =~ response_s).should_not be_nil
     ensure
       `./cnf-conformance cluster_api_cleanup`
+      wait 5.0
     end
   end
   it "'clusterapi_enabled' should fail if cluster api is not installed" do

--- a/spec/platform/cluster_api_spec.cr
+++ b/spec/platform/cluster_api_spec.cr
@@ -11,22 +11,22 @@ describe "Cluster API" do
 
   after_all do
     # cleanup cluster api stuff
-    `./cnf-conformance cluster_api_cleanup`
+    # `./cnf-conformance cluster_api_cleanup`
   end
 
   it "'clusterapi_enabled' should pass if cluster api is installed" do
     begin
       `./cnf-conformance cluster_api_setup`
-    ensure
       current_dir = FileUtils.pwd 
       FileUtils.cd("#{current_dir}")
       response_s = `./cnf-conformance clusterapi_enabled poc`
       LOGGING.info response_s
       (/Cluster API is enabled/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-conformance cluster_api_cleanup`
     end
   end
   it "'clusterapi_enabled' should fail if cluster api is not installed" do
-    `./cnf-conformance cluster_api_cleanup`
     response_s = `./cnf-conformance clusterapi_enabled poc`
     LOGGING.info response_s
     (/Cluster API NOT enabled/ =~ response_s).should_not be_nil

--- a/spec/platform/cluster_api_spec.cr
+++ b/spec/platform/cluster_api_spec.cr
@@ -24,7 +24,6 @@ describe "Cluster API" do
       (/Cluster API is enabled/ =~ response_s).should_not be_nil
     ensure
       `./cnf-conformance cluster_api_cleanup`
-      sleep 5.0
     end
   end
   it "'clusterapi_enabled' should fail if cluster api is not installed" do

--- a/spec/platform/cluster_api_spec.cr
+++ b/spec/platform/cluster_api_spec.cr
@@ -24,7 +24,7 @@ describe "Cluster API" do
       (/Cluster API is enabled/ =~ response_s).should_not be_nil
     ensure
       `./cnf-conformance cluster_api_cleanup`
-      wait 5.0
+      sleep 5.0
     end
   end
   it "'clusterapi_enabled' should fail if cluster api is not installed" do

--- a/spec/platform/cluster_api_spec.cr
+++ b/spec/platform/cluster_api_spec.cr
@@ -11,71 +11,25 @@ describe "Cluster API" do
 
   after_all do
     # cleanup cluster api stuff
-    current_dir = FileUtils.pwd 
-    cluster_api_dir = "#{current_dir}/#{TOOLS_DIR}/cluster-api"
-    `kubectl delete -f #{cluster_api_dir}/capd.yaml`
-    `clusterctl delete --all --include-crd --include-namespace --config #{cluster_api_dir}/clusterctl.yaml`
-    `rm -rf #{current_dir}/#{TOOLS_DIR}/cluster-api`
+    `./cnf-conformance cluster_api_cleanup`
   end
 
-  it "'clusterapi_enabled' test works" do
+  it "'clusterapi_enabled' should pass if cluster api is installed" do
     begin
-      # `./tools/cluster-api-dev-setup/spec_mock_cluster_api_spec_commands.sh`
+      `./cnf-conformance cluster_api_setup`
+    ensure
       current_dir = FileUtils.pwd 
-      cluster_api_dir =  "#{current_dir}/#{TOOLS_DIR}/cluster-api";
-      unless Dir.exists?(cluster_api_dir)
-        `git clone https://github.com/kubernetes-sigs/cluster-api --depth 1 --branch v0.3.10 "#{cluster_api_dir}"`
-      end
-      FileUtils.cd(cluster_api_dir)
-      File.write("clusterctl-settings.json",
-<<-EOF
-{"providers": ["cluster-api","bootstrap-kubeadm","control-plane-kubeadm", "infrastructure-docker"]}
-EOF
-  )
-      `./cmd/clusterctl/hack/create-local-repository.py`
-      File.write("clusterctl.yaml", 
-<<-EOF
-providers:
-  - name: docker
-    url: #{Path["~"].expand(home: true)}/.cluster-api/dev-repository/infrastructure-docker/v0.3.8/infrastructure-components.yaml
-    type: InfrastructureProvider
-EOF
-  )
-
-
-      test = `clusterctl init --core cluster-api:v0.3.8  --bootstrap kubeadm:v0.3.8    --control-plane kubeadm:v0.3.8    --infrastructure docker:v0.3.8 --config #{FileUtils.pwd}/clusterctl.yaml`
-      puts test
-
-      $?.success?.should be_true
-
-
-      ## TODO: wait here for crds to be created if needed
-create_capd_response =`
-CNI_RESOURCES="$(cat test/e2e/data/cni/kindnet/kindnet.yaml)" \
-DOCKER_POD_CIDRS="192.168.0.0/16" \
-DOCKER_SERVICE_CIDRS="172.17.0.0/16" \
-DOCKER_SERVICE_DOMAIN="cluster.local" \
-clusterctl config cluster capd --kubernetes-version v1.17.5 \
---from https://github.com/kubernetes-sigs/cluster-api/blob/v0.3.9/test/e2e/data/infrastructure-docker/cluster-template.yaml \
---target-namespace default \
---control-plane-machine-count=1 \
---worker-machine-count=2
-`
-
-      LOGGING.info create_capd_response 
-
-      File.write("capd.yaml", create_capd_response)
-
-      CNFManager.wait_for_install_by_apply("capd.yaml")
-
-      LOGGING.info `kubectl apply -f capd.yaml`
-
-      ensure
-        FileUtils.cd("#{current_dir}")
-        response_s = `./cnf-conformance clusterapi_enabled poc`
-        LOGGING.info response_s
-        (/Cluster API is enabled/ =~ response_s).should_not be_nil
+      FileUtils.cd("#{current_dir}")
+      response_s = `./cnf-conformance clusterapi_enabled poc`
+      LOGGING.info response_s
+      (/Cluster API is enabled/ =~ response_s).should_not be_nil
     end
+  end
+  it "'clusterapi_enabled' should fail if cluster api is not installed" do
+    `./cnf-conformance cluster_api_cleanup`
+    response_s = `./cnf-conformance clusterapi_enabled poc`
+    LOGGING.info response_s
+    (/Cluster API NOT enabled/ =~ response_s).should_not be_nil
   end
 end
 

--- a/src/tasks/cluster_api_setup.cr
+++ b/src/tasks/cluster_api_setup.cr
@@ -4,7 +4,7 @@ require "colorize"
 require "totem"
 require "./utils/utils.cr"
 
-desc "Install Cluster API"
+desc "Install Cluster API for Kind"
 task "cluster_api_setup" do |_, args|
       # `./tools/cluster-api-dev-setup/spec_mock_cluster_api_spec_commands.sh`
       current_dir = FileUtils.pwd 

--- a/src/tasks/cluster_api_setup.cr
+++ b/src/tasks/cluster_api_setup.cr
@@ -1,0 +1,66 @@
+require "sam"
+require "file_utils"
+require "colorize"
+require "totem"
+require "./utils/utils.cr"
+
+desc "Install Cluster API"
+task "cluster_api_setup" do |_, args|
+      # `./tools/cluster-api-dev-setup/spec_mock_cluster_api_spec_commands.sh`
+      current_dir = FileUtils.pwd 
+      cluster_api_dir =  "#{current_dir}/#{TOOLS_DIR}/cluster-api";
+      unless Dir.exists?(cluster_api_dir)
+        `git clone https://github.com/kubernetes-sigs/cluster-api --depth 1 --branch v0.3.10 "#{cluster_api_dir}"`
+      end
+      FileUtils.cd(cluster_api_dir)
+      File.write("clusterctl-settings.json",
+<<-EOF
+{"providers": ["cluster-api","bootstrap-kubeadm","control-plane-kubeadm", "infrastructure-docker"]}
+EOF
+  )
+      `./cmd/clusterctl/hack/create-local-repository.py`
+      File.write("clusterctl.yaml", 
+<<-EOF
+providers:
+  - name: docker
+    url: #{Path["~"].expand(home: true)}/.cluster-api/dev-repository/infrastructure-docker/v0.3.8/infrastructure-components.yaml
+    type: InfrastructureProvider
+EOF
+  )
+
+
+      test = `clusterctl init --core cluster-api:v0.3.8  --bootstrap kubeadm:v0.3.8    --control-plane kubeadm:v0.3.8    --infrastructure docker:v0.3.8 --config #{FileUtils.pwd}/clusterctl.yaml`
+      LOGGING.info test
+
+      ## TODO: wait here for crds to be created if needed
+create_capd_response =`
+CNI_RESOURCES="$(cat test/e2e/data/cni/kindnet/kindnet.yaml)" \
+DOCKER_POD_CIDRS="192.168.0.0/16" \
+DOCKER_SERVICE_CIDRS="172.17.0.0/16" \
+DOCKER_SERVICE_DOMAIN="cluster.local" \
+clusterctl config cluster capd --kubernetes-version v1.17.5 \
+--from https://github.com/kubernetes-sigs/cluster-api/blob/v0.3.9/test/e2e/data/infrastructure-docker/cluster-template.yaml \
+--target-namespace default \
+--control-plane-machine-count=1 \
+--worker-machine-count=2
+`
+
+      LOGGING.info create_capd_response 
+
+      File.write("capd.yaml", create_capd_response)
+
+      CNFManager.wait_for_install_by_apply("capd.yaml")
+
+      LOGGING.info `kubectl apply -f capd.yaml`
+end
+
+desc "Cleanup Cluster API"
+task "cluster_api_cleanup" do |_, args|
+  current_dir = FileUtils.pwd 
+  cluster_api_dir = "#{current_dir}/#{TOOLS_DIR}/cluster-api"
+  `kubectl delete -f #{cluster_api_dir}/capd.yaml`
+  `clusterctl delete --all --include-crd --include-namespace --config #{cluster_api_dir}/clusterctl.yaml`
+  `rm -rf #{current_dir}/#{TOOLS_DIR}/cluster-api`
+
+end
+

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -107,7 +107,7 @@ task "clusterapi_enabled" do |_, args|
     clusterapi_control_planes_json = proc_clusterapi_control_planes_json.call
     LOGGING.info("clusterapi_control_planes_json: #{clusterapi_control_planes_json}")
 
-    if clusterapi_namespaces_json["items"]?.not_nil! && clusterapi_namespaces_json["items"].as_a.size > 0 && clusterapi_control_planes_json["items"]?.not_nil! && clusterapi_control_planes_json["items"].as_a.size > 0
+    if clusterapi_namespaces_json["items"]? && clusterapi_namespaces_json["items"].as_a.size > 0 && clusterapi_control_planes_json["items"]? && clusterapi_control_planes_json["items"].as_a.size > 0
       resp = upsert_passed_task("clusterapi_enabled", "✔️ Cluster API is enabled ✨")
     else
       resp = upsert_failed_task("clusterapi_enabled","✖️  Cluster API NOT enabled ✨")


### PR DESCRIPTION
#328 cluster api now has a negative test

## Description
328 cluster api now has a negative test

## Issues:
Refs: #328

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
