### PR TITLE
The build should not be triggered for documentation changes #478

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -71,8 +71,9 @@ jobs:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       run: |
-        # if git diff --name-only HEAD master | grep -P '^((?!.md).)*$'  == nil
-        LOG_LEVEL=info crystal spec --warnings none ${{ matrix.spec }} -v
+        if ! git diff --name-only HEAD master | grep -P '^((?!.md).)*$'; then
+          LOG_LEVEL=info crystal spec --warnings none ${{ matrix.spec }} -v
+        fi
   build:
     name: Build Release
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -71,6 +71,7 @@ jobs:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       run: |
+        # if git diff --name-only HEAD master | grep -P '^((?!.md).)*$'  == nil
         LOG_LEVEL=info crystal spec --warnings none ${{ matrix.spec }} -v
   build:
     name: Build Release

--- a/example-cnfs/nsm/README.md
+++ b/example-cnfs/nsm/README.md
@@ -1,6 +1,6 @@
 # What is [NSM](https://https://networkservicemesh.io//)
 
-Network Service Mesh (NSM) is a novel approach solving complicated L2/L3 use cases in Kubernetes that are tricky to address with the existing Kubernetes Network Model. Inspired by Istio, Network Service Mesh maps the concept of a Service Mesh to L2/L3 payloads as part of an attempt to re-imagine NFV in a Cloud-native way!
+Network Service Mesh (NSM) is a novel approach solving complicated L2/L3 use cases in Kubernetes that are tricky to address with the existing Kubernetes Network Model. Inspired by Istio, Network Service Mesh maps the concept of a Service Mesh to L2/L3 payloads as part of an attempt to re-imagine NFV in a Cloud-native way.
 
 # Prerequistes
 Follow [Pre-req steps](https://github.com/cncf/cnf-conformance/blob/master/INSTALL.md#prerequisites), including


### PR DESCRIPTION
# The build should not be triggered for documentation changes #478

## Description
The build should not be triggered for documentation changes #478

## Issues:
Refs: #478

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
