### PR TITLE
#485 sidecar container example now uses tag 1.16.0

### DIFF
--- a/sample-cnfs/k8s-sidecar-container-pattern/cnf-conformance.yml
+++ b/sample-cnfs/k8s-sidecar-container-pattern/cnf-conformance.yml
@@ -20,5 +20,5 @@ container_names:
   - name: sidecar-container2
     upgrade_test_tag: "1.32.0"
   - name: main-container
-    upgrade_test_tag: "1.9.9"
+    upgrade_test_tag: "1.16.0"
 white_list_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/src/tasks/utils/docker_client.cr
+++ b/src/tasks/utils/docker_client.cr
@@ -22,6 +22,7 @@ module DockerClient
       modified_tag = tag == nil ? "latest" : tag
       latest_image = docker_image_list.parse("json")["results"].as_a.find{|x|x["name"]=="#{modified_tag}"} 
       LOGGING.debug "docker parse resp: #{latest_image}"
+      (LOGGING.error "no image found for tag: #{modified_tag}") if latest_image == nil
       latest_image 
     end
   end

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -17,6 +17,7 @@ module KubectlClient
   end
   module Set
     def self.image(deployment_name, container_name, image_name, version_tag=nil)
+      #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
       if version_tag
         # use --record to have history
         resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record`


### PR DESCRIPTION
# #485 sidecar container example now uses tag 1.16.0

## Description
#485 sidecar container example now uses tag 1.16.0

## Issues:
Refs: #485

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
