### PR TITLE
Feat(resiliency): Add litmus pod network latency test

### DIFF
--- a/points.yml
+++ b/points.yml
@@ -45,6 +45,8 @@
 #  tags: scalability, dynamic, workload
 - name: network_chaos 
   tags: scalability, dynamic, workload
+- name: pod-network-latency
+  tags: scalability, dynamic, workload
 #- name: external_retry 
 #  tags: scalability, dynamic, workload
 

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -113,7 +113,7 @@ describe "Utils" do
 
   it "'all_task_test_names' should return all tasks names" do
     clean_results_yml
-    (all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "rollback", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found", "no_local_volume_configuration"])
+    (all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "pod-network-latency", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "rollback", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found", "no_local_volume_configuration"])
   end
 
   it "'all_result_test_names' should return the tasks assigned to a tag" do

--- a/spec/workload/resilience/pod_network_latency_spec.cr
+++ b/spec/workload/resilience/pod_network_latency_spec.cr
@@ -1,0 +1,28 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/tasks/utils/utils.cr"
+require "../../../src/tasks/utils/system_information/helm.cr"
+require "file_utils"
+require "sam"
+
+describe "Resilience Pod Network Latency Chaos" do
+  before_all do
+    `./cnf-conformance setup`
+    `./cnf-conformance configuration_file_setup`
+    $?.success?.should be_true
+  end
+
+  it "'pod_network_latency' A 'Good' CNF should not crash when network latency occurs", tags: ["pod_network_latency"]  do
+    begin
+      `./cnf-conformance cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
+      $?.success?.should be_true
+      response_s = `./cnf-conformance pod-network-latency verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: pod-network-latency chaos test passed/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
+      $?.success?.should be_true
+    end
+  end
+end

--- a/spec/workload/resilience/pod_network_latency_spec.cr
+++ b/spec/workload/resilience/pod_network_latency_spec.cr
@@ -23,6 +23,8 @@ describe "Resilience Pod Network Latency Chaos" do
     ensure
       `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
       $?.success?.should be_true
+      `./cnf-conformance uninstall_litmus`
+      $?.success?.should be_true
     end
   end
 end

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -5,7 +5,7 @@ require "totem"
 
 desc "Cleans up the CNF Conformance test suite, the K8s cluster, and upstream projects"
 # task "cleanup", ["samples_cleanup", "results_yml_cleanup"] do  |_, args|
-task "cleanup", ["samples_cleanup", "uninstall_chaosmesh"] do  |_, args|
+task "cleanup", ["samples_cleanup", "uninstall_chaosmesh","uninstall_litmus"] do  |_, args|
 end
 
 desc "Cleans up the CNF Conformance sample projects"

--- a/src/tasks/litmus_cleanup.cr
+++ b/src/tasks/litmus_cleanup.cr
@@ -1,0 +1,13 @@
+require "sam"
+require "file_utils"
+require "colorize"
+require "totem"
+require "./utils/utils.cr"
+
+desc "Uninstall LitmusChaos"
+task "uninstall_litmus" do |_, args|
+    uninstall_chaosengine = `kubectl delete chaosengine --all --all-namespaces`
+    litmus_uninstall = `kubectl delete -f https://litmuschaos.github.io/litmus/litmus-operator-v1.11.0.yaml`
+    puts "#{uninstall_chaosengine}" if check_verbose(args)
+    puts "#{litmus_uninstall}" if check_verbose(args)
+end

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -6,14 +6,8 @@ require "./utils/utils.cr"
 
 desc "Install LitmusChaos"
 task "install_litmus" do |_, args|
-    litmus_install = `kubectl apply -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-v1.9.1.yaml`
+    litmus_install = `kubectl apply -f https://litmuschaos.github.io/litmus/litmus-operator-v1.11.0.yaml`
     puts "#{litmus_install}" if check_verbose(args)
-end
-
-desc "Uninstall LitmusChaos"
-task "uninstall_litmus" do |_, args|
-    litmus_uninstall = `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-v1.9.1.yaml`
-    puts "#{litmus_uninstall}" if check_verbose(args)
 end
 
 module LitmusManager
@@ -24,13 +18,13 @@ module LitmusManager
     delay=15
     retry=60
     chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
-    wait_count = 0 
+    wait_count = 0
     status_code = -1 
     experimentStatus = ""
     experimentStatus_cmd = "kubectl get chaosengine.litmuschaos.io #{test_name} -o jsonpath='{.status.engineStatus}'"
     puts "Checking experiment status  #{experimentStatus_cmd}" if check_verbose(args)
 
-    ## Wait for completion of chaosengine which indicates the complition of chaos  
+    ## Wait for completion of chaosengine which indicates the completion of chaos  
     until (status_code == 0 && experimentStatus == "Completed") || wait_count >= retry
       sleep delay
       experimentStatus_cmd = "kubectl get chaosengine.litmuschaos.io #{test_name} -o jsonpath='{.status.experiments[0].status}'"
@@ -78,5 +72,4 @@ module LitmusManager
     
     resp
   end
-
 end

--- a/src/tasks/litmuschaos_setup.cr
+++ b/src/tasks/litmuschaos_setup.cr
@@ -6,13 +6,13 @@ require "./utils/utils.cr"
 
 desc "Install LitmusChaos"
 task "install_litmus" do |_, args|
-    litmus_install = `kubectl apply -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-latest.yaml`
+    litmus_install = `kubectl apply -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-v1.9.1.yaml`
     puts "#{litmus_install}" if check_verbose(args)
 end
 
 desc "Uninstall LitmusChaos"
 task "uninstall_litmus" do |_, args|
-    litmus_uninstall = `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-latest.yaml`
+    litmus_uninstall = `kubectl delete -f https://raw.githubusercontent.com/litmuschaos/litmus/master/docs/litmus-operator-v1.9.1.yaml`
     puts "#{litmus_uninstall}" if check_verbose(args)
 end
 
@@ -26,9 +26,6 @@ module LitmusManager
     chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
     wait_count = 0 
     status_code = -1 
-    verdict = ""
-    verdict_cmd = "kubectl get chaosresults.litmuschaos.io #{chaos_result_name} -o jsonpath='{.status.experimentstatus.verdict}'" 
-    puts "Checking experiment verdict  #{verdict_cmd}" if check_verbose(args)
     experimentStatus = ""
     experimentStatus_cmd = "kubectl get chaosengine.litmuschaos.io #{test_name} -o jsonpath='{.status.engineStatus}'"
     puts "Checking experiment status  #{experimentStatus_cmd}" if check_verbose(args)
@@ -49,6 +46,9 @@ module LitmusManager
       end
     end
 
+    verdict = ""
+    verdict_cmd = "kubectl get chaosresults.litmuschaos.io #{chaos_result_name} -o jsonpath='{.status.experimentstatus.verdict}'" 
+    puts "Checking experiment verdict  #{verdict_cmd}" if check_verbose(args)
     ## Check the chaosresult verdict
     until (status_code == 0 && verdict != "Awaited") || wait_count >= 20
       sleep 2

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -174,9 +174,9 @@ task "pod-network-latency", ["install_litmus", "retrieve_manifest"] do |_, args|
     puts "#{destination_cnf_dir}"
     LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
     deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
-    install_experiment = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/generic/pod-network-latency/experiment.yaml`
-    install_rbac = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/generic/pod-network-latency/rbac.yaml`
-    annotate = `kubectl annotate deploy/#{deployment_name} litmuschaos.io/chaos="true"`
+    install_experiment = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/experiment.yaml`
+    install_rbac = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/rbac.yaml`
+    annotate = `kubectl annotate --overwrite deploy/#{deployment_name} litmuschaos.io/chaos="true"`
     puts "#{install_experiment}" if check_verbose(args)
     puts "#{install_rbac}" if check_verbose(args)
     puts "#{annotate}" if check_verbose(args)
@@ -200,6 +200,7 @@ task "pod-network-latency", ["install_litmus", "retrieve_manifest"] do |_, args|
 
     LitmusManager.wait_for_test(test_name,chaos_experiment_name,args)
     LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)
+
   end
 end
 
@@ -297,9 +298,6 @@ def chaos_template_pod_network_latency
 
               - name: NETWORK_INTERFACE
                 value: 'eth0'     
-
-              - name: LIB_IMAGE
-                value: 'litmuschaos/go-runner:latest'
 
               - name: NETWORK_LATENCY
                 value: '60000'

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -163,8 +163,6 @@ task "chaos_container_kill", ["install_chaosmesh", "retrieve_manifest"] do |_, a
   end
 end
 
-
-
 desc "Does the CNF crash when network latency occurs"
 task "pod-network-latency", ["install_litmus", "retrieve_manifest"] do |_, args|
   task_response = task_runner(args) do |args|
@@ -199,10 +197,6 @@ task "pod-network-latency", ["install_litmus", "retrieve_manifest"] do |_, args|
     puts "#{chaos_config}" if check_verbose(args)
     run_chaos = `kubectl apply -f "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
     puts "#{run_chaos}" if check_verbose(args)
-
-    describe_chaos_result = "kubectl describe chaosresults.litmuschaos.io #{chaos_result_name}"
-    puts "initial checkin of #{describe_chaos_result}" if check_verbose(args)  
-    puts `#{describe_chaos_result}` if check_verbose(args) 
 
     LitmusManager.wait_for_test(test_name,chaos_experiment_name,args)
     LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)
@@ -289,7 +283,7 @@ def chaos_template_pod_network_latency
     monitoring: false
     appinfo: 
       appns: 'default'
-      applabel: '{{ deployment_label}}': '{{ deployment_label_value }}'
+      applabel: '{{ deployment_label}}={{ deployment_label_value }}'
       appkind: 'deployment'
     chaosServiceAccount: {{ chaos_experiment_name }}-sa 
     experiments:

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -20,7 +20,7 @@ task "chaos_network_loss", ["install_chaosmesh", "retrieve_manifest"] do |_, arg
     destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
     deployment_name = config.get("deployment_name").as_s
     deployment_label = config.get("deployment_label").as_s
-    # helm_chart_container_name = config.get("helm_chart_container_name").as_s
+    #helm_chart_container_name = config.get("helm_chart_container_name").as_s
     LOGGING.debug "#{destination_cnf_dir}"
     LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
     deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
@@ -67,7 +67,7 @@ task "chaos_cpu_hog", ["install_chaosmesh", "retrieve_manifest"] do |_, args|
     destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
     deployment_name = config.get("deployment_name").as_s
     deployment_label = config.get("deployment_label").as_s
-    # helm_chart_container_name = config.get("helm_chart_container_name").as_s
+    #helm_chart_container_name = config.get("helm_chart_container_name").as_s
     LOGGING.debug "#{destination_cnf_dir}"
     LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
     deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
@@ -164,6 +164,52 @@ task "chaos_container_kill", ["install_chaosmesh", "retrieve_manifest"] do |_, a
 end
 
 
+
+desc "Does the CNF crash when network latency occurs"
+task "pod-network-latency", ["install_litmus", "retrieve_manifest"] do |_, args|
+  task_response = task_runner(args) do |args|
+    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
+    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
+    deployment_name = config.get("deployment_name").as_s
+    deployment_name = "coredns-coredns"
+    deployment_label = config.get("deployment_label").as_s
+    puts "#{destination_cnf_dir}"
+    LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
+    deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
+    install_experiment = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/generic/pod-network-latency/experiment.yaml`
+    install_rbac = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/generic/pod-network-latency/rbac.yaml`
+    annotate = `kubectl annotate deploy/#{deployment_name} litmuschaos.io/chaos="true"`
+    puts "#{install_experiment}" if check_verbose(args)
+    puts "#{install_rbac}" if check_verbose(args)
+    puts "#{annotate}" if check_verbose(args)
+    
+    errors = 0
+    begin
+      deployment_label_value = deployment.get("metadata").as_h["labels"].as_h[deployment_label].as_s
+    rescue ex
+      errors = errors + 1
+      LOGGING.error ex.message 
+    end
+    chaos_experiment_name = "pod-network-latency"
+    test_name = "#{deployment_name}-conformance-#{Time.local.to_unix}" 
+    chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
+
+    template = Crinja.render(chaos_template_pod_network_latency, {"chaos_experiment_name"=> "#{chaos_experiment_name}", "deployment_label" => "#{deployment_label}", "deployment_label_value" => "#{deployment_label_value}", "test_name" => test_name})
+    chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
+    puts "#{chaos_config}" if check_verbose(args)
+    run_chaos = `kubectl apply -f "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
+    puts "#{run_chaos}" if check_verbose(args)
+
+    describe_chaos_result = "kubectl describe chaosresults.litmuschaos.io #{chaos_result_name}"
+    puts "initial checkin of #{describe_chaos_result}" if check_verbose(args)  
+    puts `#{describe_chaos_result}` if check_verbose(args) 
+
+    LitmusManager.wait_for_test(test_name,chaos_experiment_name,args)
+    LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)
+  end
+end
+
+
 def network_chaos_template
   <<-TEMPLATE
   apiVersion: pingcap.com/v1alpha1
@@ -227,3 +273,56 @@ def chaos_template_container_kill
       cron: '@every 600s'
   TEMPLATE
 end
+
+def chaos_template_pod_network_latency
+  <<-TEMPLATE
+  apiVersion: litmuschaos.io/v1alpha1
+  kind: ChaosEngine
+  metadata:
+    name: {{ test_name }}
+    namespace: default
+  spec: 
+    jobCleanUpPolicy: 'delete'
+    annotationCheck: 'true'
+    engineState: 'active'
+    auxiliaryAppInfo: ''
+    monitoring: false
+    appinfo: 
+      appns: 'default'
+      applabel: '{{ deployment_label}}': '{{ deployment_label_value }}'
+      appkind: 'deployment'
+    chaosServiceAccount: {{ chaos_experiment_name }}-sa 
+    experiments:
+      - name: {{ chaos_experiment_name }}
+        spec:
+          components:
+            env:
+              # If not provided it will take the first container of target pod
+              - name: TARGET_CONTAINER
+                value: '' 
+
+              - name: NETWORK_INTERFACE
+                value: 'eth0'     
+
+              - name: LIB_IMAGE
+                value: 'litmuschaos/go-runner:latest'
+
+              - name: NETWORK_LATENCY
+                value: '60000'
+
+              - name: TOTAL_CHAOS_DURATION
+                value: '60' # in seconds
+
+              # provide the name of container runtime
+              # it supports docker, containerd, crio
+              # default to docker
+              - name: CONTAINER_RUNTIME
+                value: 'containerd'
+
+              # provide the socket file path
+              # applicable only for containerd and crio runtime
+              - name: SOCKET_PATH
+                value: '/run/containerd/containerd.sock'
+
+  TEMPLATE
+  end


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

## Description

- This PR adds a litmus test to check the resiliency of the CNF application when subject to network latency for a certain chaos duration. 

## Issues:
Refs: 
- [Resilience test: is CNF healthy after pod-network-latency Litmus Chaos test? #520](https://github.com/cncf/cnf-conformance/issues/520)
- EPIC to add various litmus probes: https://github.com/cncf/cnf-conformance/issues/499

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [X] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [X] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [X] Tasks in issue are checked off
