### PR TITLE
release manager now uses first entry in rev-parse

### DIFF
--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -169,11 +169,11 @@ TEMPLATE
   end
   module CompileTimeVersionGenerater
     macro tagged_version
-      {% current_branch = `git rev-parse --abbrev-ref HEAD`.split("\n")[0] %}
+      {% current_branch = `git rev-parse --abbrev-ref HEAD`.split("\n")[0].strip %}
       {% current_hash = `git rev-parse --short HEAD` %}
       {% current_tag = `git tag --points-at HEAD` %}
       {% if current_tag.strip == "" %}
-        VERSION = "{{current_branch.strip}}-{{current_hash.strip}}"
+        VERSION = {{current_branch}} + "-{{current_hash.strip}}"
       {% else %}
         VERSION = "{{current_tag.strip}}"
       {% end %}

--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -195,7 +195,7 @@ TEMPLATE
   end
 
   def self.current_branch
-    results = `git rev-parse --abbrev-ref HEAD`
+    results = `git rev-parse --abbrev-ref HEAD`.split("\n")[0].strip
     LOGGING.info "current_branch rev-parse: #{results}"
     results.strip("\n")
   end

--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -169,7 +169,7 @@ TEMPLATE
   end
   module CompileTimeVersionGenerater
     macro tagged_version
-      {% current_branch = `git rev-parse --abbrev-ref HEAD` %}
+      {% current_branch = `git rev-parse --abbrev-ref HEAD`.split("\n")[0] %}
       {% current_hash = `git rev-parse --short HEAD` %}
       {% current_tag = `git tag --points-at HEAD` %}
       {% if current_tag.strip == "" %}


### PR DESCRIPTION
#release manager now uses first entry in rev-parse

## Description
release manager now uses first entry in rev-parse

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
