### PR TITLE
Updated test-cat and usage to include rollback (rolling_downgrade)

### DIFF
--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -52,8 +52,8 @@ The CNF Conformance program validates interoperability of CNF **workloads** supp
 *  Checking if the pod/container can be started without mounting a volume (e.g. using [helm configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/)) that has configuration files
 *  Testing to see if we can start pods/containers and see that the application continues to perform (e.g. using [Litmus](https://github.com/litmuschaos/litmus))
 *  Testing by reseting any child processes, and when the parent process is started, checking to see if those child processes are reaped (ie. monitoring processes with [Falco](https://github.com/falcosecurity/falco) or [sysdig-inspect](https://github.com/draios/sysdig-inspect))
-*  Testing if the CNF can perform a rolling update (i.e. [kubectl rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/))
-*  Testing if the CNF can perform a rolling_downgrade and rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision))
+*  Testing if the CNF can perform a rolling update (also rolling downgrade) (i.e. [kubectl rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/))
+*  Testing if the CNF can perform a rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision))
 *  Testing if there are any (non-declarative) hardcoded IP addresses or subnet masks 
 
 ## Observability Tests 

--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -53,7 +53,7 @@ The CNF Conformance program validates interoperability of CNF **workloads** supp
 *  Testing to see if we can start pods/containers and see that the application continues to perform (e.g. using [Litmus](https://github.com/litmuschaos/litmus))
 *  Testing by reseting any child processes, and when the parent process is started, checking to see if those child processes are reaped (ie. monitoring processes with [Falco](https://github.com/falcosecurity/falco) or [sysdig-inspect](https://github.com/draios/sysdig-inspect))
 *  Testing if the CNF can perform a rolling update (i.e. [kubectl rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/))
-*  Testing if the CNF can perform a rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision))
+*  Testing if the CNF can perform a rolling_downgrade and rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision))
 *  Testing if there are any (non-declarative) hardcoded IP addresses or subnet masks 
 
 ## Observability Tests 

--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -53,7 +53,7 @@ The CNF Conformance program validates interoperability of CNF **workloads** supp
 *  Testing to see if we can start pods/containers and see that the application continues to perform (e.g. using [Litmus](https://github.com/litmuschaos/litmus))
 *  Testing by reseting any child processes, and when the parent process is started, checking to see if those child processes are reaped (ie. monitoring processes with [Falco](https://github.com/falcosecurity/falco) or [sysdig-inspect](https://github.com/draios/sysdig-inspect))
 *  Testing if the CNF can perform a rolling update (i.e. [kubectl rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/))
-*  Testing if the CNF can perform a rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision)
+*  Testing if the CNF can perform a rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision))
 *  Testing if there are any (non-declarative) hardcoded IP addresses or subnet masks 
 
 ## Observability Tests 

--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -53,6 +53,7 @@ The CNF Conformance program validates interoperability of CNF **workloads** supp
 *  Testing to see if we can start pods/containers and see that the application continues to perform (e.g. using [Litmus](https://github.com/litmuschaos/litmus))
 *  Testing by reseting any child processes, and when the parent process is started, checking to see if those child processes are reaped (ie. monitoring processes with [Falco](https://github.com/falcosecurity/falco) or [sysdig-inspect](https://github.com/draios/sysdig-inspect))
 *  Testing if the CNF can perform a rolling update (i.e. [kubectl rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/))
+*  Testing if the CNF can perform a rollback (i.e. [kubectl_rollout_undo](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-to-a-previous-revision)
 *  Testing if there are any (non-declarative) hardcoded IP addresses or subnet masks 
 
 ## Observability Tests 

--- a/USAGE.md
+++ b/USAGE.md
@@ -307,11 +307,12 @@ crystal src/cnf-conformance.cr external_retry
 ./cnf-conformance hardcoded_ip_addresses_in_k8s_runtime_configuration
 ```
 
-#### :heavy_check_mark: To check if a CNF version can be downgraded through a rolling_downgrade, aka [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
+#### :heavy_check_mark: To check if a CNF version can be downgraded through a rolling_downgrade 
 ```
 ./cnf-conformance rolling_downgrade
 ```
-or
+
+#### :heavy_check_mark: To check if a CNF version can be rolled back [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
 ```
 ./cnf-conformance rollback
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -307,6 +307,15 @@ crystal src/cnf-conformance.cr external_retry
 ./cnf-conformance hardcoded_ip_addresses_in_k8s_runtime_configuration
 ```
 
+#### :heavy_check_mark: To check if a CNF version can be downgraded through a rolling_downgrade, aka [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
+```
+./cnf-conformance rolling_downgrade
+```
+or
+```
+./cnf-conformance rollback
+```
+
 <details> <summary>Details for Configuration and Lifecycle Tests To Do's</summary>
 <p>
 
@@ -396,15 +405,6 @@ Now run the test:
 #### :heavy_check_mark: To test if the CNF can perform a [rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/)
 ```
 ./cnf-conformance rolling_update
-```
-
-#### :heavy_check_mark: To check if a CNF version can be downgraded through a rolling_downgrade, aka [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
-```
-./cnf-conformance rolling_downgrade
-```
-or
-```
-./cnf-conformance rollback
 ```
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -395,7 +395,16 @@ Now run the test:
 
 #### :heavy_check_mark: To test if the CNF can perform a [rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/)
 ```
-crystal src/cnf-conformance.cr rolling_update
+./cnf-conformance rolling_update
+```
+
+#### :heavy_check_mark: To check if a CNF version can be downgraded through a rolling_downgrade, aka [rollback](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
+```
+./cnf-conformance rolling_downgrade
+```
+or
+```
+./cnf-conformance rollback
 ```
 
 ---


### PR DESCRIPTION
### Description
Missing doc updates for #82

--
### Documentation is updated:
- [x] On https://github.com/cncf/cnf-conformance/blob/master/USAGE.md#installable-and-upgradeable-tests, I can see:
     - [x] the `rolling_downgrade`  test added to the USAGE.md and marked with a checkmark (or POC, depending on what is completed in this issue) 
     - [x] a new sentence describing what the `rolling_downgrade` test does
- [x] On https://github.com/cncf/cnf-conformance/blob/master/TEST-CATEGORIES.md#installable-and-upgradeable-tests, I can see a new sentence about `rolling_deployment_downgrade` 

## Issues:
Refs: #82 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
