### PR TITLE
release manager git tag now scrapes git status

### DIFF
--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -36,8 +36,8 @@ module ReleaseManager
         draft = true 
       end
       LOGGING.info "upsert_version: #{upsert_version}"
-      LOGGING.info "upsert_version comparison: upsert_version =~ /(?i)(master|v[0-1]|test_version)/ : #{upsert_version =~ /(?i)(master|v[0-1]|test_version)/}"
-      unless upsert_version =~ /(?i)(master|v[0-1]|test_version)/
+      LOGGING.info "upsert_version comparison: upsert_version =~ /(?i)(master|v[0-9]|test_version)/ : #{upsert_version =~ /(?i)(master|v[0-9]|test_version)/}"
+      unless upsert_version =~ /(?i)(master|v[0-9]|test_version)/
         LOGGING.info "Not creating a release for : #{upsert_version}"
         return {found_release, asset} 
       end
@@ -171,7 +171,7 @@ TEMPLATE
     macro tagged_version
       {% current_branch = `git rev-parse --abbrev-ref HEAD`.split("\n")[0].strip %}
       {% current_hash = `git rev-parse --short HEAD` %}
-      {% current_tag = `git tag --points-at HEAD` %}
+      {% current_tag = `git status | grep -oP 'HEAD.*\K(v[0-9]+[0-9]?\.[0-9]+[0-9]?(\.[0-9]+[0-9]?)?)' || true` %}
       {% if current_tag.strip == "" %}
         VERSION = {{current_branch}} + "-{{current_hash.strip}}"
       {% else %}


### PR DESCRIPTION
# release manager git tag now scrapes git status

## Description
release manager git tag now scrapes git status

## Issues:
Refs: #NNN

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
