### PR TITLE
Add support for additional K8s workload resource kinds: Pod, ReplicaSet, StatefulSet, Daemonset #531

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -161,7 +161,7 @@ jobs:
       with:
         fetch-depth: 0
     - uses: mxschmitt/action-tmate@v3
-      # if: needs.debug_output.outputs.build-debug == 'true'
+      if: needs.debug_output.outputs.build-debug == 'true'
     - name: Install Crystal
       env:
         CRYSTAL_VERSION: 0.35.1

--- a/sample-cnfs/sample-local-storage/cnf-conformance.yml
+++ b/sample-cnfs/sample-local-storage/cnf-conformance.yml
@@ -10,7 +10,7 @@ application_deployment_names:
 - coredns
 helm_chart: stable/coredns
 helm_chart_container_name: coredns
-container_names: 
-  - name: coredns 
-    rolling_update_test_tag: "1.8.0"
+container_names:
+- name: coredns
+  rolling_update_test_tag: 1.8.0
 white_list_helm_chart_container_names: []

--- a/sample-cnfs/sample-statefulset-cnf/README.md
+++ b/sample-cnfs/sample-statefulset-cnf/README.md
@@ -1,0 +1,39 @@
+# Set up Sample CoreDNS CNF
+./sample-cnfs/sample-coredns-cnf/readme.md
+# Prerequistes
+### Install helm
+```
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+```
+### Optional: Use a helm version manager
+https://github.com/yuya-takeyama/helmenv
+Check out helmenv into any path (here is ${HOME}/.helmenv)
+```
+${HOME}/.helmenv)
+$ git clone https://github.com/yuya-takeyama/helmenv.git ~/.helmenv
+```
+Add ~/.helmenv/bin to your $PATH any way you like
+```
+$ echo 'export PATH="$HOME/.helmenv/bin:$PATH"' >> ~/.bash_profile
+```
+```
+helmenv versions 
+helmenv install <version 3.1?>
+```
+
+### core-dns installation
+```
+helm install coredns stable/coredns
+```
+### Pull down the helm chart code, untar it, and put it in the cnfs/coredns directory
+```
+helm pull stable/coredns
+```
+### Example cnf-conformance config file for sample-core-dns-cnf
+In ./cnfs/sample-core-dns-cnf/cnf-conformance.yml
+```
+---
+container_names: [coredns-coredns] 
+```

--- a/sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml
+++ b/sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml
@@ -1,0 +1,27 @@
+---
+helm_directory: helm_chart
+git_clone_url: 
+install_script: 
+release_name: my-release --set mariadb.primary.persistence.enabled=false --set persistence.enabled=false 
+deployment_name: my-release-wordpress 
+deployment_label: app.kubernetes.io/name
+service_name: 
+application_deployment_names: [my-release-wordpress]
+docker_repository: bitnami/wordpress 
+helm_repository:
+  name: bitnami 
+  repo_url: https://charts.bitnami.com/bitnami 
+helm_chart: bitnami/wordpress 
+helm_chart_container_name: busybox 
+white_list_helm_chart_container_names: [falco, nginx, coredns, calico-node, kube-proxy, nginx-proxy]
+container_names: 
+  - name: wordpress 
+    rolling_update_test_tag: "5.6.0-debian-10-r11"
+    rolling_downgrade_test_tag: 5.6.0-debian-10-r10 
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
+  - name: mariadb
+    rolling_update_test_tag: "10.5.8-debian-10-r21"
+    rolling_downgrade_test_tag: 10.5.8-debian-10-r20 
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest

--- a/spec/cnf_conformance_all/cnf_conformance_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_spec.cr
@@ -28,6 +28,8 @@ describe CnfConformance do
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil
     (all_result_test_names(CNFManager.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published","helm_deploy", "reasonable_image_size", "reasonable_startup_time", "rollback" ].sort)
+    (/^.*\.cr:[0-9]/ =~ response_s).should be_nil
+
     $?.success?.should be_true
   end
 end

--- a/spec/cnf_conformance_all/cnf_conformance_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_spec.cr
@@ -29,7 +29,6 @@ describe CnfConformance do
     (/Final score:/ =~ response_s).should_not be_nil
     (all_result_test_names(CNFManager.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published","helm_deploy", "reasonable_image_size", "reasonable_startup_time", "rollback" ].sort)
     (/^.*\.cr:[0-9]/ =~ response_s).should be_nil
-
     $?.success?.should be_true
   end
 end

--- a/spec/fixtures/cnf-conformance.yml
+++ b/spec/fixtures/cnf-conformance.yml
@@ -13,7 +13,10 @@ helm_chart: stable/coredns
 helm_chart_container_name: coredns
 container_names: 
   - name: coredns 
-    rolling_update_test_tag: 1.8.0 
+    rolling_update_test_tag: "1.8.0"
+    rolling_downgrade_test_tag: 1.6.7
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
 white_list_helm_chart_container_names:
 - falco
 - node-cache

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -355,5 +355,6 @@ describe "Utils" do
       update_yml("spec/fixtures/cnf-conformance.yml", "release_name", "coredns")
     end
   end
+
 end
 

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -14,14 +14,17 @@ describe CnfConformance do
   end
   it "'privileged' should pass with a non-privileged cnf", tags: ["privileged", "happy-path"]  do
     begin
-      `./cnf-conformance sample_coredns_setup`
-      $?.success?.should be_true
-      response_s = `./cnf-conformance privileged cnf-config=sample-cnfs/sample-coredns-cnf verbose`
+      # `./cnf-conformance sample_coredns_setup`
+      # $?.success?.should be_true
+      # response_s = `./cnf-conformance privileged cnf-config=sample-cnfs/sample-coredns-cnf verbose`
+      LOGGING.debug `./cnf-conformance cnf_setup cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml`
+      response_s = `./cnf-conformance privileged verbose`
       LOGGING.info response_s
       $?.success?.should be_true
       (/Found.*privileged containers.*coredns/ =~ response_s).should be_nil
     ensure
-      `./cnf-conformance sample_coredns_cleanup`
+      # `./cnf-conformance sample_coredns_cleanup`
+      LOGGING.debug `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml`
     end
   end
   it "'privileged' should fail on a non-whitelisted, privileged cnf", tags: "privileged" do

--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -26,7 +26,7 @@ end
 
 desc "The CNF Conformance program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
 task "workload", ["all_prereqs", "configuration_file_setup", "compatibility","statelessness", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_and_scheduling", "microservice", "resilience"] do  |_, args|
-  VERBOSE_LOGGING.info "all" if check_verbose(args)
+  VERBOSE_LOGGING.info "workload" if check_verbose(args)
 
   total = total_points("workload")
   if total > 0

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -30,7 +30,7 @@ module CNFManager
                                      helm_chart_container_name: String,
                                      rolling_update_tag: String,
                                      container_names: Array(Hash(String, String )) | Nil,
-                                     white_list_helm_chart_container_names: String) 
+                                     white_list_container_names: Array(String)) 
 
     def self.parse_config_yml(config_yml_path) : CNFManager::Config
       config = CNFManager.parsed_config_file(
@@ -46,6 +46,9 @@ module CNFManager
       service_name = optional_key_as_string(config, "service_name")
       helm_chart_path = destination_cnf_dir + "/" + helm_directory
       manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
+      white_list_container_names = config.get("white_list_helm_chart_container_names").as_a.map do |c|
+        "#{c.as_s?}"
+      end
       container_names_totem = config["container_names"]
       container_names = container_names_totem.as_a.map do |container|
         {"name" => optional_key_as_string(container, "name"),
@@ -76,7 +79,7 @@ module CNFManager
                                helm_chart_container_name: "",
                                rolling_update_tag: "",
                                container_names: container_names,
-                               white_list_helm_chart_container_names: ""} )
+                               white_list_container_names: white_list_container_names })
 
     end
   end
@@ -117,6 +120,7 @@ module CNFManager
         containers.as_a.each do |container|
           resp = yield resource, container, initialized
           LOGGING.debug "yield resp: #{resp}"
+          # if any response is false, the test fails
           test_passed = false if resp == false
         end
       end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -45,6 +45,15 @@ module CNFManager
       release_name = "#{config.get("release_name").as_s?}"
       helm_chart_path = destination_cnf_dir + "/" + helm_directory
       manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
+      container_names_totem = config["container_names"]
+      container_names = container_names_totem.as_a.map do |container|
+        {"name" => optional_key_as_string(container, "name"),
+         "rolling_update_test_tag" => optional_key_as_string(container, "rolling_update_test_tag"),
+         "rolling_downgrade_test_tag" => optional_key_as_string(container, "rolling_downgrade_test_tag"),
+         "rolling_version_change_test_tag" => optional_key_as_string(container, "rolling_version_change_test_tag"),
+         "rollback_from_tag" => optional_key_as_string(container, "rollback_from_tag"),
+         }
+      end
 
       # TODO populate nils with entries from cnf-conformance file
       CNFManager::Config.new({ destination_cnf_dir: destination_cnf_dir,
@@ -65,7 +74,7 @@ module CNFManager
                                helm_chart: "",
                                helm_chart_container_name: "",
                                rolling_update_tag: "",
-                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
+                               container_names: container_names,
                                white_list_helm_chart_container_names: ""} )
 
     end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -192,34 +192,6 @@ module CNFManager
 
   def self.wait_for_install(deployment_name, wait_count : Int32 = 180, namespace="default")
     resource_wait_for_install("deployment", deployment_name, wait_count, namespace)
-    # Not all cnfs have deployments.  some have only a pod.  need to check if the 
-    # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod 
-    # second_count = 0
-    # all_deployments = `kubectl get deployments --namespace=#{namespace}`
-    # LOGGING.debug "all_deployments #{all_deployments}"
-    # desired_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.replicas}'`
-    # LOGGING.debug "desired_replicas #{desired_replicas}"
-    # current_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
-    # LOGGING.debug "current_replicas #{current_replicas}"
-    # LOGGING.info(all_deployments)
-    #
-    # until (current_replicas.empty? != true && current_replicas.to_i == desired_replicas.to_i) || second_count > wait_count
-    #   LOGGING.info("second_count = #{second_count}")
-    #   sleep 1
-    #   all_deployments = `kubectl get deployments --namespace=#{namespace}`
-    #   current_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
-    #   # Sometimes desired replicas is not available immediately
-    #   desired_replicas = `kubectl get deployments --namespace=#{namespace} #{deployment_name} -o=jsonpath='{.status.replicas}'`
-    #   LOGGING.debug "desired_replicas #{desired_replicas}"
-    #   LOGGING.info(all_deployments)
-    #   second_count = second_count + 1 
-    # end
-    #
-    # if (current_replicas.empty? != true && current_replicas.to_i == desired_replicas.to_i)
-    #   true
-    # else
-    #   false
-    # end
   end
 
   def self.resource_wait_for_install(kind, resource_name, wait_count : Int32 = 180, namespace="default")

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -5,6 +5,24 @@ require "./types/cnf_conformance_yml_type.cr"
 
 module CNFManager 
 
+  class Config
+    property cnf_config : NamedTuple(helm_directory: String | Nil, 
+                                     git_clone_url: String | Nil,
+                                     install_script: String | Nil,
+                                     release_name: String | Nil,
+                                     deployment_name: String | Nil,
+                                     deployment_label: String | Nil,
+                                     service_name:  String | Nil,
+                                     application_deployment_names: String | Nil,
+                                     docker_repository: String | Nil,
+                                     helm_repository: NamedTuple(name:  String | Nil, repo_url:  String | Nil) | Nil,
+                                     helm_chart:  String | Nil,
+                                     helm_chart_container_name: String | Nil,
+                                     rolling_update_tag: String | Nil,
+                                     container_names: Array(NamedTuple(name:  String | Nil, upgrade_test_tag: String | Nil) | Nil ) | Nil,
+                                     white_list_helm_chart_container_names: String | Nil) | Nil
+  end
+
   def self.final_cnf_results_yml
     results_file = `find ./results/* -name "cnf-conformance-results-*.yml"`.split("\n")[-2].gsub("./", "")
     if results_file.empty?

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -43,7 +43,7 @@ module CNFManager
       helm_directory = "#{config.get("helm_directory").as_s?}"
       manifest_directory = optional_key_as_string(config, "manifest_directory")
       release_name = "#{config.get("release_name").as_s?}"
-      service_name = "#{config.get("service_name").as_s?}"
+      service_name = optional_key_as_string(config, "service_name")
       helm_chart_path = destination_cnf_dir + "/" + helm_directory
       manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
       container_names_totem = config["container_names"]

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -2,25 +2,73 @@
 require "totem"
 require "colorize"
 require "./types/cnf_conformance_yml_type.cr"
+require "./helm.cr"
 
 module CNFManager 
 
   class Config
-    property cnf_config : NamedTuple(helm_directory: String | Nil, 
-                                     git_clone_url: String | Nil,
-                                     install_script: String | Nil,
-                                     release_name: String | Nil,
-                                     deployment_name: String | Nil,
-                                     deployment_label: String | Nil,
-                                     service_name:  String | Nil,
-                                     application_deployment_names: String | Nil,
-                                     docker_repository: String | Nil,
-                                     helm_repository: NamedTuple(name:  String | Nil, repo_url:  String | Nil) | Nil,
-                                     helm_chart:  String | Nil,
-                                     helm_chart_container_name: String | Nil,
-                                     rolling_update_tag: String | Nil,
-                                     container_names: Array(NamedTuple(name:  String | Nil, upgrade_test_tag: String | Nil) | Nil ) | Nil,
-                                     white_list_helm_chart_container_names: String | Nil) | Nil
+    def initialize(cnf_config)
+      @cnf_config = cnf_config 
+    end
+    property cnf_config : NamedTuple(destination_cnf_dir: String,
+                                     yml_file_path: String,
+                                     manifest_directory: String,
+                                     helm_directory: String, 
+                                     helm_chart_path: String, 
+                                     manifest_file_path: String, 
+                                     git_clone_url: String,
+                                     install_script: String,
+                                     release_name: String,
+                                     deployment_name: String,
+                                     deployment_label: String,
+                                     service_name:  String,
+                                     application_deployment_names: String,
+                                     docker_repository: String,
+                                     helm_repository: NamedTuple(name:  String, 
+                                                                 repo_url:  String) | Nil,
+                                     helm_chart:  String,
+                                     helm_chart_container_name: String,
+                                     rolling_update_tag: String,
+                                     container_names: Array(Hash(String, String )) | Nil,
+                                     white_list_helm_chart_container_names: String) 
+
+    def self.parse_config_yml(config_yml_path) : CNFManager::Config
+      config = CNFManager.parsed_config_file(
+        CNFManager.ensure_cnf_conformance_yml_path(config_yml_path))
+
+      destination_cnf_dir = CNFManager.cnf_destination_dir(
+        CNFManager.ensure_cnf_conformance_dir(config_yml_path))
+
+      yml_file_path = CNFManager.ensure_cnf_conformance_dir(config_yml_path)
+      helm_directory = "#{config.get("helm_directory").as_s?}"
+      manifest_directory = optional_key_as_string(config, "manifest_directory")
+      release_name = "#{config.get("release_name").as_s?}"
+      helm_chart_path = destination_cnf_dir + "/" + helm_directory
+      manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
+
+      # TODO populate nils with entries from cnf-conformance file
+      CNFManager::Config.new({ destination_cnf_dir: destination_cnf_dir,
+                               yml_file_path: yml_file_path,
+                               manifest_directory: manifest_directory,
+                               helm_directory: helm_directory, 
+                               helm_chart_path: helm_chart_path, 
+                               manifest_file_path: manifest_file_path,
+                               git_clone_url: "",
+                               install_script: "",
+                               release_name: release_name,
+                               deployment_name: "",
+                               deployment_label: "",
+                               service_name: "",
+                               application_deployment_names: "",
+                               docker_repository: "",
+                               helm_repository: {name: "", repo_url: ""},
+                               helm_chart: "",
+                               helm_chart_container_name: "",
+                               rolling_update_tag: "",
+                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
+                               white_list_helm_chart_container_names: ""} )
+
+    end
   end
 
   def self.final_cnf_results_yml
@@ -344,6 +392,50 @@ module CNFManager
 
     sample_setup(config_file: config_dir, release_name: release_name, deployment_name: deployment_name, helm_chart: helm_chart, helm_directory: helm_directory, git_clone_url: git_clone_url, deploy_with_chart: deploy_with_chart, verbose: verbose, wait_count: wait_count, manifest_directory: manifest_directory, install_from_manifest: install_from_manifest )
 
+  end
+
+  #test_passes_completely = workload_resource_test do | cnf_config, resource, container, initialized |
+  def self.workload_resource_test(args, config, &block)
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
+    yml_file_path = config.cnf_config[:yml_file_path] 
+    # TODO remove helm_directory and use base cnf directory
+    helm_directory = config.cnf_config[:helm_directory]
+    manifest_directory = config.cnf_config[:manifest_directory] 
+    release_name = config.cnf_config[:release_name]
+    helm_chart_path = config.cnf_config[:helm_chart_path]
+    manifest_file_path = config.cnf_config[:manifest_file_path]
+    test_passed = true
+    if release_name.empty? # no helm chart
+      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
+    else
+      Helm.generate_manifest_from_templates(release_name, 
+                                            helm_chart_path, 
+                                            manifest_file_path)
+      template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
+    end
+    resource_ymls = Helm.all_workload_resources(template_ymls)
+    resource_names = Helm.workload_resource_kind_names(resource_ymls)
+    LOGGING.info "resource names: #{resource_names}"
+    if resource_names && resource_names.size > 0 
+      initialized = true
+    else
+      LOGGING.error "no resource names found"
+      initialized = false
+    end
+		resource_names.each do | resource |
+			VERBOSE_LOGGING.debug resource.inspect if check_verbose(args)
+      #TODO create get resource containers
+      unless resource[:kind].as_s.downcase == "service" ## services have no containers
+        containers = KubectlClient::Get.resource_containers(resource[:kind], resource[:name])
+        containers.as_a.each do |container|
+          resp = yield resource, container, initialized
+          LOGGING.debug "yield resp: #{resp}"
+          test_passed = false if resp == false
+        end
+      end
+    end
+    LOGGING.debug "workload resource test intialized: #{initialized} test_passed: #{test_passed}"
+    initialized && test_passed
   end
 
   def self.sample_setup(config_file, release_name, deployment_name, helm_chart, helm_directory, manifest_directory = "", git_clone_url="", deploy_with_chart=true, verbose=false, wait_count=180, install_from_manifest=false)

--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -57,8 +57,6 @@ module Helm
   def self.workload_resource_by_kind(ymls : Array(YAML::Any), kind)
     LOGGING.info "workload_resource_by_kind kind: #{kind}"
     LOGGING.debug "workload_resource_by_kind ymls: #{ymls}"
-    # resources = ymls.map do |yml|
-      # yml.as_a.select{|x| x["kind"]?==kind}
     resources = ymls.select{|x| x["kind"]?==kind}
     # end
     LOGGING.debug "resources: #{resources}"
@@ -66,9 +64,9 @@ module Helm
   end
 
   def self.all_workload_resources(yml : Array(YAML::Any))
-    resources = KubectlClient::WORKLOAD_RESOURCES.maps do |_, resource_kind|
-      workload_resource_by_kind(yml, resource_kind)
-    end
+    resources = KubectlClient::WORKLOAD_RESOURCES.map { |k,v| 
+      Helm.workload_resource_by_kind(yml, v)
+    }.flatten
     LOGGING.debug "all resource: #{resources}"
     resources
   end

--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -5,12 +5,10 @@ require "halite"
 
 module Helm
 
-  # TODO change constants to named tuples
-  # https://crystal-lang.org/reference/syntax_and_semantics/literals/named_tuple.html
+  #TODO move to kubectlclient
   DEPLOYMENT="Deployment"
   SERVICE="Service"
   POD="Pod"
-
 
   # Utilities for manifest files that are not templates or have been converted already
   module Manifest
@@ -67,9 +65,25 @@ module Helm
     resources
   end
 
+  def self.all_workload_resources(yml : Array(YAML::Any))
+    resources = KubectlClient::WORKLOAD_RESOURCES.maps do |_, resource_kind|
+      workload_resource_by_kind(yml, resource_kind)
+    end
+    LOGGING.debug "all resource: #{resources}"
+    resources
+  end
+
   def self.workload_resource_names(resources : Array(YAML::Any) )
     resource_names = resources.map do |x|
       x["metadata"]["name"]
+    end
+    LOGGING.debug "resource names: #{resource_names}"
+    resource_names
+  end
+
+  def self.workload_resource_kind_names(resources : Array(YAML::Any) )
+    resource_names = resources.map do |x|
+      {kind: x["kind"], name: x["metadata"]["name"]}
     end
     LOGGING.debug "resource names: #{resource_names}"
     resource_names

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -4,6 +4,13 @@ require "./cnf_manager.cr"
 require "halite"
 
 module KubectlClient 
+  WORKLOAD_RESOURCES = {deployment: "Deployment", 
+                        service: "Service", 
+                        pod: "Pod", 
+                        replicaset: "ReplicaSet", 
+                        statefulset: "StatefulSet", 
+                        daemonset: "DaemonSet"}
+
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
   module Rollout

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -69,7 +69,7 @@ module KubectlClient
     def self.deployment(deployment_name) : JSON::Any
       resp = `kubectl get deployment #{deployment_name} -o json`
       LOGGING.debug "kubectl get deployment: #{resp}"
-      if resp 
+      if resp && !resp.empty?
         JSON.parse(resp)
       else
         JSON.parse(%({}))
@@ -80,7 +80,7 @@ module KubectlClient
       LOGGING.debug "kubectl get kind: #{kind} resource name: #{resource_name}"
       resp = `kubectl get #{kind} #{resource_name} -o json`
       LOGGING.debug "kubectl get resource: #{resp}"
-      if resp 
+      if resp && !resp.empty?
         JSON.parse(resp)
       else
         JSON.parse(%({}))
@@ -96,7 +96,7 @@ module KubectlClient
     def self.deployments : JSON::Any
       resp = `kubectl get deployments -o json`
       LOGGING.debug "kubectl get deployment: #{resp}"
-      if resp 
+      if resp && !resp.empty?
         JSON.parse(resp)
       else
         JSON.parse(%({}))
@@ -113,10 +113,10 @@ module KubectlClient
         resp = resource(kind, resource_name).dig?("spec", "template", "spec", "containers")
       end
       LOGGING.debug "kubectl get resource containers: #{resp}"
-      if resp 
+      if resp && resp.as_a.size > 0
         resp
       else
-        JSON.parse(%({}))
+        JSON.parse(%([]))
       end
     end
     def self.resource_desired_is_available?(kind, resource_name)
@@ -146,7 +146,7 @@ module KubectlClient
       LOGGING.debug "resource_labels kind: #{kind} resource_name: #{resource_name}"
       resp = resource(kind, resource_name).dig?("spec", "template", "metadata", "labels")
       LOGGING.debug "resource_labels: #{resp}"
-      if resp 
+      if resp
         resp
       else
         JSON.parse(%({}))

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -61,7 +61,22 @@ module KubectlClient
     def self.deployment(deployment_name) : JSON::Any
       resp = `kubectl get deployment #{deployment_name} -o json`
       LOGGING.debug "kubectl get deployment: #{resp}"
-      JSON.parse(resp)
+      if resp 
+        JSON.parse(resp)
+      else
+        JSON.parse(%({}))
+      end
+    end
+
+    def self.resource(kind, resource_name) : JSON::Any
+      LOGGING.debug "kubectl get kind: #{kind} resource name: #{resource_name}"
+      resp = `kubectl get #{kind} #{resource_name} -o json`
+      LOGGING.debug "kubectl get resource: #{resp}"
+      if resp 
+        JSON.parse(resp)
+      else
+        JSON.parse(%({}))
+      end
     end
 
     def self.save_manifest(deployment_name, output_file) 
@@ -73,13 +88,30 @@ module KubectlClient
     def self.deployments : JSON::Any
       resp = `kubectl get deployments -o json`
       LOGGING.debug "kubectl get deployment: #{resp}"
-      JSON.parse(resp)
+      if resp 
+        JSON.parse(resp)
+      else
+        JSON.parse(%({}))
+      end
     end
 
     def self.deployment_containers(deployment_name) : JSON::Any 
       LOGGING.debug "kubectl get deployment containers deployment_name: #{deployment_name}"
       resp = deployment(deployment_name).dig?("spec", "template", "spec", "containers")
       LOGGING.debug "kubectl get deployment containers: #{resp}"
+      if resp 
+        resp
+      else
+        JSON.parse(%({}))
+      end
+    end
+
+    def self.resource_containers(kind, resource_name) : JSON::Any 
+      LOGGING.debug "kubectl get resource containers kind: #{kind} resource_name: #{resource_name}"
+      unless kind.as_s.downcase == "service" ## services have no containers
+        resp = resource(kind, resource_name).dig?("spec", "template", "spec", "containers")
+      end
+      LOGGING.debug "kubectl get resource containers: #{resp}"
       if resp 
         resp
       else

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -21,6 +21,14 @@ module KubectlClient
       LOGGING.debug "rollout? #{rollout_status}"
       $?.success?
     end
+    def self.resource_status(kind, resource_name, timeout="30s")
+      rollout = `kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}`
+      rollout_status = $?.success?
+      LOGGING.debug "#{rollout}"
+      LOGGING.debug "rollout? #{rollout_status}"
+      $?.success?
+    end
+
     def self.undo(deployment_name)
       rollback = `kubectl rollout undo deployment/#{deployment_name}`
       rollback_status = $?.success?

--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -174,7 +174,6 @@ TEMPLATE
       {% current_hash = `git rev-parse --short HEAD` %}
       {% current_status = `git status`.split("\n")[0].strip %}
       {% current_tag = (!`git tag --points-at HEAD`.empty? && `git tag --points-at HEAD`.split("\n")[-2].strip) || `git tag --points-at HEAD` %} 
-      {% puts "git status during compile: #{`git status`}" %}
       {% puts "current_branch during compile: #{current_branch}" %}
       {% puts "current_tag during compile: #{current_tag}" %}
       {% if current_tag.strip == "" %}

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -80,7 +80,7 @@ def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | 
                                helm_chart_container_name: "",
                                rolling_update_tag: "",
                                container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
-                               white_list_helm_chart_container_names: ""} )
+                               white_list_container_names: [""]} )
     end
     yield args, config
   rescue ex

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -30,6 +30,70 @@ EmbeddedFileManager.node_failure_values
 EmbeddedFileManager.cri_tools
 EmbeddedFileManager.reboot_daemon
 
+def task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
+  # LOGGING.info("single_or_all_cnfs_task_runner: #{args.inspect}")
+  if check_cnf_config(args)
+    single_task_runner(args, &block)
+  else
+    all_cnfs_task_runner(args, &block)
+  end
+end
+
+# TODO give example for calling
+def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config  -> String | Colorize::Object(String) | Nil)
+
+  # Platforms tests dont have any cnfs
+  if CNFManager.cnf_config_list(silent: true).size == 0
+    single_task_runner(args, &block)
+  else
+    CNFManager.cnf_config_list(silent: true).map do |x|
+      new_args = Sam::Args.new(args.named, args.raw)
+      new_args.named["cnf-config"] = x
+      single_task_runner(new_args, &block)
+    end
+  end
+end
+
+# TODO give example for calling
+def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
+  LOGGING.debug("task_runner args: #{args.inspect}")
+  begin
+    if args.named["cnf-config"]? # platform tests don't have a cnf-config
+      config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
+    else
+      config = CNFManager::Config.new({ destination_cnf_dir: "",
+                               yml_file_path: "",
+                               manifest_directory: "",
+                               helm_directory: "", 
+                               helm_chart_path: "", 
+                               manifest_file_path: "",
+                               git_clone_url: "",
+                               install_script: "",
+                               release_name: "",
+                               deployment_name: "",
+                               deployment_label: "",
+                               service_name: "",
+                               application_deployment_names: "",
+                               docker_repository: "",
+                               helm_repository: {name: "", repo_url: ""},
+                               helm_chart: "",
+                               helm_chart_container_name: "",
+                               rolling_update_tag: "",
+                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
+                               white_list_helm_chart_container_names: ""} )
+    end
+    yield args, config
+  rescue ex
+    # Set exception key/value in results
+    # file to -1
+    update_yml("#{Results.file}", "exit_code", "1")
+    LOGGING.error ex.message
+    ex.backtrace.each do |x|
+      LOGGING.error x
+    end
+  end
+end
+
 def log_formatter
   Log::Formatter.new do |entry, io|
     progname = "cnf-conformance"
@@ -223,70 +287,6 @@ end
 def check_cnf_config_then_deploy(args)
   config_file, deploy_with_chart = check_all_cnf_args(args)
   CNFManager.sample_setup_args(sample_dir: config_file, deploy_with_chart: deploy_with_chart, args: args, verbose: check_verbose(args) ) if config_file
-end
-
-def task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
-  # LOGGING.info("single_or_all_cnfs_task_runner: #{args.inspect}")
-  if check_cnf_config(args)
-    single_task_runner(args, &block)
-  else
-    all_cnfs_task_runner(args, &block)
-  end
-end
-
-# TODO give example for calling
-def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config  -> String | Colorize::Object(String) | Nil)
-
-  # Platforms tests dont have any cnfs
-  if CNFManager.cnf_config_list(silent: true).size == 0
-    single_task_runner(args, &block)
-  else
-    CNFManager.cnf_config_list(silent: true).map do |x|
-      new_args = Sam::Args.new(args.named, args.raw)
-      new_args.named["cnf-config"] = x
-      single_task_runner(new_args, &block)
-    end
-  end
-end
-
-# TODO give example for calling
-def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
-  LOGGING.debug("task_runner args: #{args.inspect}")
-  begin
-    if args.named["cnf-config"]? # platform tests don't have a cnf-config
-      config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
-    else
-      config = CNFManager::Config.new({ destination_cnf_dir: "",
-                               yml_file_path: "",
-                               manifest_directory: "",
-                               helm_directory: "", 
-                               helm_chart_path: "", 
-                               manifest_file_path: "",
-                               git_clone_url: "",
-                               install_script: "",
-                               release_name: "",
-                               deployment_name: "",
-                               deployment_label: "",
-                               service_name: "",
-                               application_deployment_names: "",
-                               docker_repository: "",
-                               helm_repository: {name: "", repo_url: ""},
-                               helm_chart: "",
-                               helm_chart_container_name: "",
-                               rolling_update_tag: "",
-                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
-                               white_list_helm_chart_container_names: ""} )
-    end
-    yield args, config
-  rescue ex
-    # Set exception key/value in results
-    # file to -1
-    update_yml("#{Results.file}", "exit_code", "1")
-    LOGGING.error ex.message
-    ex.backtrace.each do |x|
-      LOGGING.error x
-    end
-  end
 end
 
 def toggle(toggle_name)

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -654,19 +654,5 @@ def optional_key_as_string(totem_config, key_name)
   "#{totem_config[key_name]? && totem_config[key_name].as_s?}"
 end
 
-def desired_is_available?(deployment_name)
-  resp = `kubectl get deployments #{deployment_name} -o=yaml`
-  describe = Totem.from_yaml(resp)
-  LOGGING.info("desired_is_available describe: #{describe.inspect}")
-  desired_replicas = describe.get("status").as_h["replicas"].as_i
-  LOGGING.info("desired_is_available desired_replicas: #{desired_replicas}")
-  ready_replicas = describe.get("status").as_h["readyReplicas"]?
-  unless ready_replicas.nil?
-    ready_replicas = ready_replicas.as_i
-  else
-    ready_replicas = 0
-  end
-  LOGGING.info("desired_is_available ready_replicas: #{ready_replicas}")
-
-  desired_replicas == ready_replicas
-end
+# TODO move to kubectl_client
+# TODO make resource version

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -253,7 +253,30 @@ end
 def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
   LOGGING.debug("task_runner args: #{args.inspect}")
   begin
-    config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
+    if args.named["cnf-config"]? # platform tests don't have a cnf-config
+      config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
+    else
+      config = CNFManager::Config.new({ destination_cnf_dir: "",
+                               yml_file_path: "",
+                               manifest_directory: "",
+                               helm_directory: "", 
+                               helm_chart_path: "", 
+                               manifest_file_path: "",
+                               git_clone_url: "",
+                               install_script: "",
+                               release_name: "",
+                               deployment_name: "",
+                               deployment_label: "",
+                               service_name: "",
+                               application_deployment_names: "",
+                               docker_repository: "",
+                               helm_repository: {name: "", repo_url: ""},
+                               helm_chart: "",
+                               helm_chart_container_name: "",
+                               rolling_update_tag: "",
+                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
+                               white_list_helm_chart_container_names: ""} )
+    end
     yield args, config
   rescue ex
     # Set exception key/value in results

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -225,7 +225,7 @@ def check_cnf_config_then_deploy(args)
   CNFManager.sample_setup_args(sample_dir: config_file, deploy_with_chart: deploy_with_chart, args: args, verbose: check_verbose(args) ) if config_file
 end
 
-def task_runner(args, &block : Sam::Args, CNFManager::Config | Nil -> String | Colorize::Object(String) | Nil)
+def task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
   # LOGGING.info("single_or_all_cnfs_task_runner: #{args.inspect}")
   if check_cnf_config(args)
     single_task_runner(args, &block)
@@ -235,7 +235,7 @@ def task_runner(args, &block : Sam::Args, CNFManager::Config | Nil -> String | C
 end
 
 # TODO give example for calling
-def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config | Nil  -> String | Colorize::Object(String) | Nil)
+def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config  -> String | Colorize::Object(String) | Nil)
 
   # Platforms tests dont have any cnfs
   if CNFManager.cnf_config_list(silent: true).size == 0
@@ -250,9 +250,10 @@ def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config | Nil  -> 
 end
 
 # TODO give example for calling
-def single_task_runner(args, config=nil, &block : Sam::Args, CNFManager::Config | Nil  -> String | Colorize::Object(String) | Nil)
+def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
   # LOGGING.info("task_runner args: #{args.inspect}")
   # TODO instantiate and populate CNFManager::Config.cnf_config from config file
+  config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
   begin
   yield args, config
   rescue ex

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -225,7 +225,7 @@ def check_cnf_config_then_deploy(args)
   CNFManager.sample_setup_args(sample_dir: config_file, deploy_with_chart: deploy_with_chart, args: args, verbose: check_verbose(args) ) if config_file
 end
 
-def task_runner(args, &block : Sam::Args -> String | Colorize::Object(String) | Nil)
+def task_runner(args, &block : Sam::Args, CNFManager::Config | Nil -> String | Colorize::Object(String) | Nil)
   # LOGGING.info("single_or_all_cnfs_task_runner: #{args.inspect}")
   if check_cnf_config(args)
     single_task_runner(args, &block)
@@ -235,7 +235,7 @@ def task_runner(args, &block : Sam::Args -> String | Colorize::Object(String) | 
 end
 
 # TODO give example for calling
-def all_cnfs_task_runner(args, &block : Sam::Args -> String | Colorize::Object(String) | Nil)
+def all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config | Nil  -> String | Colorize::Object(String) | Nil)
 
   # Platforms tests dont have any cnfs
   if CNFManager.cnf_config_list(silent: true).size == 0
@@ -250,10 +250,11 @@ def all_cnfs_task_runner(args, &block : Sam::Args -> String | Colorize::Object(S
 end
 
 # TODO give example for calling
-def single_task_runner(args, &block)
+def single_task_runner(args, config=nil, &block : Sam::Args, CNFManager::Config | Nil  -> String | Colorize::Object(String) | Nil)
   # LOGGING.info("task_runner args: #{args.inspect}")
+  # TODO instantiate and populate CNFManager::Config.cnf_config from config file
   begin
-  yield args
+  yield args, config
   rescue ex
     # Set exception key/value in results
     # file to -1

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -251,11 +251,10 @@ end
 
 # TODO give example for calling
 def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
-  # LOGGING.info("task_runner args: #{args.inspect}")
-  # TODO instantiate and populate CNFManager::Config.cnf_config from config file
-  config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
+  LOGGING.debug("task_runner args: #{args.inspect}")
   begin
-  yield args, config
+    config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
+    yield args, config
   rescue ex
     # Set exception key/value in results
     # file to -1

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -54,7 +54,7 @@ end
 desc "Is there a liveness entry in the helm chart?"
 task "liveness", ["retrieve_manifest"] do |_, args|
   task_runner(args) do |args, config|
-    LOGGING.debug "cnf_config: #{config.cnf_config}"
+    LOGGING.debug "cnf_config: #{config}"
     VERBOSE_LOGGING.info "liveness" if check_verbose(args)
     resp = ""
     emoji_probe="🧫"

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -118,7 +118,6 @@ task "retrieve_manifest" do |_, args|
     # config = cnf_conformance_yml
     config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
     deployment_name = config.get("deployment_name").as_s
-    # TODO get this from k8s manifest kind = service
     service_name = "#{config.get("service_name").as_s?}"
     VERBOSE_LOGGING.debug "Deployment_name: #{deployment_name}" if check_verbose(args)
     VERBOSE_LOGGING.debug service_name if check_verbose(args)

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -15,17 +15,17 @@ end
 
 desc "Does a search for IP addresses or subnets come back as negative?"
 task "ip_addresses" do |_, args|
-  task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "ip_addresses" if check_verbose(args)
     LOGGING.info("ip_addresses args #{args.inspect}")
     cdir = FileUtils.pwd()
     response = String::Builder.new
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    helm_directory = "#{config.get("helm_directory").as_s?}" 
-    LOGGING.info "ip_addresses helm_directory: #{CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)) + helm_directory}"
-    if File.directory?(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)) + helm_directory)
+    # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
+    helm_directory = config.cnf_config[:helm_directory]
+    helm_chart_path = config.cnf_config[:helm_chart_path]
+    if File.directory?(helm_chart_path)
       # Switch to the helm chart directory
-      Dir.cd(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)) + helm_directory)
+      Dir.cd(helm_chart_path)
       # Look for all ip addresses that are not comments
       LOGGING.info "current directory: #{ FileUtils.pwd()}"
       # should catch comments (# // or /*) and ignore 0.0.0.0

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -20,7 +20,6 @@ task "ip_addresses" do |_, args|
     LOGGING.info("ip_addresses args #{args.inspect}")
     cdir = FileUtils.pwd()
     response = String::Builder.new
-    # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
     helm_directory = config.cnf_config[:helm_directory]
     helm_chart_path = config.cnf_config[:helm_chart_path]
     if File.directory?(helm_chart_path)
@@ -139,27 +138,27 @@ task "retrieve_manifest" do |_, args|
   end
 end
 
-def get_helm_chart_values(sam_args, release_name)
-  # helm_chart_values = JSON.parse(`#{CNFManager.local_helm_path} get values #{release_name} -a --output json`)
-  LOGGING.info "helm path: #{CNFSingleton.helm}"
-  LOGGING.info "helm command: #{CNFSingleton.helm} get values #{release_name} -a --output json"
-  helm_resp = `#{CNFSingleton.helm} get values #{release_name} -a --output json`
-  # helm sometimes does not return valid json :/
-  helm_split = helm_resp.split("\n")
-  LOGGING.info "helm_split: #{helm_split}"
-  if helm_split[1] =~ /WARNING/ 
-    cleaned_resp = helm_split[2] 
-  elsif helm_split[0] =~ /WARNING/
-    cleaned_resp = helm_split[1] 
-  else
-    cleaned_resp = helm_split[0]
-  end
-  LOGGING.info "cleaned_resp: #{cleaned_resp}"
-  helm_chart_values = JSON.parse(cleaned_resp)
-  VERBOSE_LOGGING.debug "helm_chart_values" if check_verbose(sam_args)
-  VERBOSE_LOGGING.debug helm_chart_values if check_verbose(sam_args)
-  helm_chart_values
-end
+# def get_helm_chart_values(sam_args, release_name)
+#   # helm_chart_values = JSON.parse(`#{CNFManager.local_helm_path} get values #{release_name} -a --output json`)
+#   LOGGING.info "helm path: #{CNFSingleton.helm}"
+#   LOGGING.info "helm command: #{CNFSingleton.helm} get values #{release_name} -a --output json"
+#   helm_resp = `#{CNFSingleton.helm} get values #{release_name} -a --output json`
+#   # helm sometimes does not return valid json :/
+#   helm_split = helm_resp.split("\n")
+#   LOGGING.info "helm_split: #{helm_split}"
+#   if helm_split[1] =~ /WARNING/ 
+#     cleaned_resp = helm_split[2] 
+#   elsif helm_split[0] =~ /WARNING/
+#     cleaned_resp = helm_split[1] 
+#   else
+#     cleaned_resp = helm_split[0]
+#   end
+#   LOGGING.info "cleaned_resp: #{cleaned_resp}"
+#   helm_chart_values = JSON.parse(cleaned_resp)
+#   VERBOSE_LOGGING.debug "helm_chart_values" if check_verbose(sam_args)
+#   VERBOSE_LOGGING.debug helm_chart_values if check_verbose(sam_args)
+#   helm_chart_values
+# end
 
 rolling_version_change_test_names.each do |tn|
   pretty_test_name = tn.split(/:|_/).join(" ")
@@ -167,96 +166,55 @@ rolling_version_change_test_names.each do |tn|
 
   desc "Test if the CNF containers are loosely coupled by performing a #{pretty_test_name}"
   task "#{tn}" do |_, args|
-    task_runner(args) do |args|
-      # TODO mark as destructive?
+    task_runner(args) do |args, config|
+      LOGGING.debug "cnf_config: #{config}"
       VERBOSE_LOGGING.info "#{tn}" if check_verbose(args)
-      config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-      destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-      helm_directory = "#{config.get("helm_directory").as_s?}"
-      manifest_directory = optional_key_as_string(config, "manifest_directory")
-      release_name = "#{config.get("release_name").as_s?}"
-      helm_chart_path = destination_cnf_dir + "/" + helm_directory
-      manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
-      container_names = config["container_names"]?
-        LOGGING.debug "container_names: #{container_names}"
+      container_names = config.cnf_config[:container_names]
+      LOGGING.debug "container_names: #{container_names}"
+      unless container_names
+        puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) 
+        update_applied = false
+      end
 
       # TODO use tag associated with image name string (e.g. busybox:v1.7.9) as the version tag
       # TODO optional get a valid version from the remote repo and roll to that, if no tag
       #  e.g. wget -q https://registry.hub.docker.com/v1/repositories/debian/tags -O -  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}'
       # note: all images are not on docker hub nor are they always on a docker hub compatible api
 
-      LOGGING.info "release_name: #{release_name}"
-      if release_name.empty? # no helm chart
-        template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-      else
-        Helm.generate_manifest_from_templates(release_name, 
-                                              helm_chart_path, 
-                                              manifest_file_path)
-        template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
-      end
-      deployment_ymls = Helm.workload_resource_by_kind(template_ymls, Helm::DEPLOYMENT)
-      deployment_names = Helm.workload_resource_names(deployment_ymls)
-
-      LOGGING.info "deployment names: #{deployment_names}"
-      if deployment_names && deployment_names.size > 0 
-        update_applied = true
-      else
-        update_applied = false
-      end
-
-      deployment_names.each do | deployment_name |
-        VERBOSE_LOGGING.debug deployment_name.inspect if check_verbose(args)
-        containers = KubectlClient::Get.deployment_containers(deployment_name)
-        unless container_names && !container_names.as_a.empty?
-          puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) unless container_names
-          update_applied = false
+      task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+        test_passed = true
+        LOGGING.debug "#{tn} container: #{container}"
+        LOGGING.debug "container_names: #{container_names}"
+        config_container = container_names.find{|x| x["name"]==container.as_h["name"]} if container_names
+        LOGGING.debug "config_container: #{config_container}"
+        unless config_container && config_container["#{tn}_test_tag"]? && !config_container["#{tn}_test_tag"].empty?
+          puts "Please add the container name #{container.as_h["name"]} and a corresponding #{tn}_test_tag into your cnf-conformance.yml under container names".colorize(:red)
+          # valid_cnf_conformance_yml = false
         end
 
-        valid_cnf_conformance_yml = true
-        containers.as_a.each do | container |
-          LOGGING.debug "#{tn} container: #{container}"
-          config_container = container_names.as_a.find{|x| x["name"]==container.as_h["name"]} if container_names
-          LOGGING.debug "config_container: #{config_container}"
-          unless config_container && config_container["#{tn}_test_tag"]? && !config_container["#{tn}_test_tag"].as_s.empty?
-            puts "Please add the container name #{container.as_h["name"]} and a corresponding #{tn}_test_tag into your cnf-conformance.yml under container names".colorize(:red)
-            valid_cnf_conformance_yml = false
-          end
+        if config_container
+          resp = KubectlClient::Set.image(resource["name"], 
+                                          container.as_h["name"], 
+                                          # split out image name from version tag
+                                          container.as_h["image"].as_s.split(":")[0], 
+                                          config_container["rolling_update_test_tag"]) 
+        else 
+          resp = false
         end
-        unless valid_cnf_conformance_yml
-          puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) unless container_names
-          update_applied = false
-        end
+        # If any containers dont have an update applied, fail
+        test_passed = false if resp == false
 
-        if containers.as_a.empty?
-          update_applied = false 
-        end
-        containers.as_a.each do | container |
-          LOGGING.debug "#{pretty_test_name} container: #{container}"
-          config_container = container_names.as_a.find{|x| x["name"]==container.as_h["name"]} if container_names
-          LOGGING.debug "config container: #{config_container}"
-          if config_container
-            resp = KubectlClient::Set.image(deployment_name, 
-                                            container.as_h["name"], 
-                                            # split out image name from version tag
-                                            container.as_h["image"].as_s.split(":")[0], 
-                                            config_container["rolling_update_test_tag"].as_s) 
-          else 
-            resp = false
-          end
-          # If any containers dont have an update applied, fail
-          update_applied = false if resp == false
-        end
-
-        rollout_status = KubectlClient::Rollout.status(deployment_name)
+        rollout_status = KubectlClient::Rollout.resource_status(resource["kind"], resource["name"])
         unless rollout_status 
-          update_applied = false
+          test_passed = false
         end
       end
-      if update_applied 
-        upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed" )
+      if task_response 
+        resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed" )
       else
-        upsert_failed_task("#{tn}", "✖️  FAILURE: CNF for #{pretty_test_name_capitalized} Failed")
+        resp = upsert_failed_task("#{tn}", "✖️  FAILURE: CNF for #{pretty_test_name_capitalized} Failed")
       end
+      resp
       # TODO should we roll the image back to original version in an ensure? 
       # TODO Use the kubectl rollback to history command
     end

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -242,35 +242,6 @@ task "rollback" do |_, args|
     end
 
     task_response = update_applied && CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-    # LOGGING.info "deployment names: #{deployment_names}"
-    # if deployment_names && deployment_names.size > 0 
-    #   update_applied = true
-    #   rollout_status = true
-    #   rollback_status = true 
-    #   version_change_applied = true 
-    # else
-    #   update_applied = false
-    #   rollout_status = false 
-    #   rollback_status = false 
-    #   version_change_applied = false
-    # end
-    # deployment_names.each do | deployment_name |
-    #   VERBOSE_LOGGING.debug deployment_name.inspect if check_verbose(args)
-    #   containers = KubectlClient::Get.deployment_containers(deployment_name)
-    #
-    #   container_names = config["container_names"]?
-    #     LOGGING.debug "container_names: #{container_names}"
-    #
-    #   unless container_names && !container_names.as_a.empty?
-    #     puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) unless container_names
-    #     upsert_failed_task("rolling_update", "✖️  FAILURE: CNF #{deployment_name} Rolling Update Failed")
-    #     exit 0
-    #   end
-    #
-    #   containers.as_a.each do | container |
-    #
-        # plural_containers = KubectlClient::Get.deployment_containers(deployment_name)
-        # container = plural_containers[0]
 
 
         image_name = container.as_h["name"]
@@ -293,7 +264,6 @@ task "rollback" do |_, args|
 
           version_change_applied = KubectlClient::Set.image(resource["name"], 
                                                             image_name, 
-                                                            # split out image name from version tag
                                                             image_tag, 
                                                             rollback_from_tag) 
         end
@@ -323,16 +293,12 @@ end
 
 desc "Does the CNF use NodePort"
 task "nodeport_not_used", ["retrieve_manifest"] do |_, args|
-  task_response = task_runner(args) do |args|
+  task_response = task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "nodeport_not_used" if check_verbose(args)
-    # config = cnf_conformance_yml
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    release_name = config.get("release_name").as_s
-    service_name = "#{config.get("service_name").as_s?}"
-    # current_cnf_dir_short_name = CNFManager.ensure_cnf_conformance_dir
-    # VERBOSE_LOGGING.debug current_cnf_dir_short_name if check_verbose(args)
-    # destination_cnf_dir = sample_destination_dir(current_cnf_dir_short_name)
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
+    LOGGING.debug "cnf_config: #{config}"
+    release_name = config.cnf_config[:release_name]
+    service_name  = config.cnf_config[:service_name]
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     if File.exists?("#{destination_cnf_dir}/service.yml")
       service = Totem.from_file "#{destination_cnf_dir}/service.yml"
       VERBOSE_LOGGING.debug service.inspect if check_verbose(args)

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -18,7 +18,7 @@ task "reasonable_startup_time" do |_, args|
   task_response = task_runner(args) do |args|
     VERBOSE_LOGGING.info "reasonable_startup_time" if check_verbose(args)
 
-    # config = get_parsed_cnf_conformance_yml(args)
+    # config = get_parsed_cnf_conforma(args)
     config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
     # yml_file_path = cnf_conformance_yml_file_path(args)
     # needs to be the source directory
@@ -57,8 +57,10 @@ task "reasonable_startup_time" do |_, args|
         helm_template_test = `#{helm} template --namespace=startup-test #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_test.yml`
         VERBOSE_LOGGING.info "helm_directory: #{helm_directory}" if check_verbose(args)
       end
+      #TODO Get resource ymls from reasonable_startup_test.yml
       kubectl_apply = `kubectl apply -f #{yml_file_path}/reasonable_startup_test.yml --namespace=startup-test`
       is_kubectl_applied = $?.success?
+      #TODO loop through all resource types and wait for install (pass in namespace)
       CNFManager.wait_for_install(deployment_name, wait_count=180,"startup-test")
       is_kubectl_deployed = $?.success?
     end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -19,25 +19,12 @@ task "reasonable_startup_time" do |_, args|
     VERBOSE_LOGGING.info "reasonable_startup_time" if check_verbose(args)
     LOGGING.debug "cnf_config: #{config}"
 
-    # config = get_parsed_cnf_conforma(args)
-    # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    # yml_file_path = cnf_conformance_yml_file_path(args)
-    # # needs to be the source directory
-    # yml_file_path = CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String))
-    # LOGGING.info("reasonable_startup_time yml_file_path: #{yml_file_path}")
-    # VERBOSE_LOGGING.info "yaml_path: #{yml_file_path}" if check_verbose(args)
-    #
-    # helm_chart = "#{config.get("helm_chart").as_s?}"
-    # helm_directory = "#{config.get("helm_directory").as_s?}"
-    # release_name = "#{config.get("release_name").as_s?}"
-    # deployment_name = "#{config.get("deployment_name").as_s?}"
     yml_file_path = config.cnf_config[:yml_file_path]
     helm_chart = config.cnf_config[:helm_chart]
     helm_directory = config.cnf_config[:helm_directory]
     release_name = config.cnf_config[:release_name]
     
     current_dir = FileUtils.pwd 
-    #helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
     helm = CNFSingleton.helm
     VERBOSE_LOGGING.info helm if check_verbose(args)
 
@@ -63,12 +50,12 @@ task "reasonable_startup_time" do |_, args|
         helm_template_test = `#{helm} template --namespace=startup-test #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_test.yml`
         VERBOSE_LOGGING.info "helm_directory: #{helm_directory}" if check_verbose(args)
       end
-      #TODO Get resource ymls from reasonable_startup_test.yml
+
       kubectl_apply = `kubectl apply -f #{yml_file_path}/reasonable_startup_test.yml --namespace=startup-test`
       is_kubectl_applied = $?.success?
-      #TODO loop through all resource types and wait for install (pass in namespace)
+
       template_ymls = Helm::Manifest.parse_manifest_as_ymls("#{yml_file_path}/reasonable_startup_test.yml") 
-      # task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
+
       LOGGING.debug "template_ymls: #{template_ymls}"
       task_response = template_ymls.map do | resource|
         LOGGING.debug "Waiting on resource: #{resource["metadata"]["name"]} of type #{resource["kind"]}"
@@ -79,7 +66,6 @@ task "reasonable_startup_time" do |_, args|
             resource["kind"].as_s.downcase == "replicaset"
 
           CNFManager.resource_wait_for_install(resource["kind"], resource["metadata"]["name"], wait_count=180, "startup-test")
-          # is_kubectl_deployed = $?.success?
           $?.success?
         else
           true

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -14,69 +14,43 @@ end
 
 desc "Does the CNF crash when network loss occurs"
 task "chaos_network_loss", ["install_chaosmesh", "retrieve_manifest"] do |_, args|
-  task_response = task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "chaos_network_loss" if check_verbose(args)
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    helm_directory = "#{config.get("helm_directory").as_s?}"
-    manifest_directory = optional_key_as_string(config, "manifest_directory")
-    release_name = "#{config.get("release_name").as_s?}"
-    helm_chart_path = destination_cnf_dir + "/" + helm_directory
-    manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
-    LOGGING.debug "#{destination_cnf_dir}"
-    LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
+    LOGGING.debug "cnf_config: #{config}"
     emoji_chaos_network_loss="📶☠️"
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
-    if release_name.empty? # no helm chart
-      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-    else
-      Helm.generate_manifest_from_templates(release_name, 
-                                          helm_chart_path, 
-                                          manifest_file_path)
-      template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
-    end
-
-    deployment_ymls = Helm.workload_resource_by_kind(template_ymls, Helm::DEPLOYMENT)
-    deployment_names = Helm.workload_resource_names(deployment_ymls)
-    LOGGING.info "deployment names: #{deployment_names}"
-    if deployment_names && deployment_names.size > 0 
-      test_passed = true
-    else
-        puts "No deployment names found for container kill test".colorize(:red)
-      test_passed = false
-    end
-    deployment_names.each do | deployment_name |
-
-      if KubectlClient::Get.deployment_spec_labels(deployment_name).as_h? && KubectlClient::Get.deployment_spec_labels(deployment_name).as_h.size > 0
+      if KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h? && 
+          KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h.size > 0
         test_passed = true
       else
-        puts "No deployment label found for container kill test for deployment: #{deployment_name}".colorize(:red)
+        puts "No resource label found for container kill test for resource: #{resource}".colorize(:red)
         test_passed = false
       end
 
       if test_passed
-        template = Crinja.render(network_chaos_template, { "labels" => KubectlClient::Get.deployment_spec_labels(deployment_name).as_h })
+        template = Crinja.render(network_chaos_template, { "labels" => KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h })
         chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/chaos_network_loss.yml"`
         VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_network_loss.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
         if wait_for_test("NetworkChaos", "network-loss")
           LOGGING.info( "Wait Done")
-          unless desired_is_available?(deployment_name)
+          unless KubectlClient::Get.resource_desired_is_available?(resource["kind"], resource["name"])
             test_passed = false
-            puts "Replicas did not return desired count after network chaos test for deployment: #{deployment_name}".colorize(:red)
-            # resp = upsert_failed_task("chaos_network_loss","✖️  FAILURE: Replicas did not return desired count after network chaos test #{emoji_chaos_network_loss}")
+            puts "Replicas did not return desired count after network chaos test for resource: #{resource["name"]}".colorize(:red)
           end
         else
           # TODO Change this to an exception (points = 0)
           # e.g. upsert_exception_task
           test_passed = false
-          puts "Chaosmesh failed to finish for deployment: #{deployment_name}".colorize(:red)
-          # resp = upsert_failed_task("chaos_network_loss","✖️  FAILURE: Chaosmesh failed to finish.")
+          puts "Chaosmesh failed to finish for resource: #{resource["name"]}".colorize(:red)
         end
       end
+      test_passed
     end
-    if test_passed
+    if task_response 
       resp = upsert_passed_task("chaos_network_loss","✔️  PASSED: Replicas available match desired count after network chaos test #{emoji_chaos_network_loss}")
     else
       resp = upsert_failed_task("chaos_network_loss","✖️  FAILURE: Replicas did not return desired count after network chaos test #{emoji_chaos_network_loss}")
@@ -88,66 +62,39 @@ end
 
 desc "Does the CNF crash when CPU usage is high"
 task "chaos_cpu_hog", ["install_chaosmesh", "retrieve_manifest"] do |_, args|
-  task_response = task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "chaos_cpu_hog" if check_verbose(args)
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    helm_directory = "#{config.get("helm_directory").as_s?}"
-    manifest_directory = optional_key_as_string(config, "manifest_directory")
-    release_name = "#{config.get("release_name").as_s?}"
-    helm_chart_path = destination_cnf_dir + "/" + helm_directory
-    manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
-    LOGGING.debug "#{destination_cnf_dir}"
-    LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
+    LOGGING.debug "cnf_config: #{config}"
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     emoji_chaos_cpu_hog="📦💻🐷📈"
-
-    if release_name.empty? # no helm chart
-      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-    else
-      Helm.generate_manifest_from_templates(release_name, 
-                                          helm_chart_path, 
-                                          manifest_file_path)
-      template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
-    end
-
-    deployment_ymls = Helm.workload_resource_by_kind(template_ymls, Helm::DEPLOYMENT)
-    deployment_names = Helm.workload_resource_names(deployment_ymls)
-    LOGGING.info "deployment names: #{deployment_names}"
-    if deployment_names && deployment_names.size > 0 
-      test_passed = true
-    else
-        puts "No deployment names found for container kill test".colorize(:red)
-      test_passed = false
-    end
-    deployment_names.each do | deployment_name |
-      if KubectlClient::Get.deployment_spec_labels(deployment_name).as_h? && KubectlClient::Get.deployment_spec_labels(deployment_name).as_h.size > 0
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h.size > 0
         test_passed = true
       else
-        puts "No deployment label found for container kill test for deployment: #{deployment_name}".colorize(:red)
+        puts "No resource label found for container kill test for resource: #{resource["name"]}".colorize(:red)
         test_passed = false
       end
       if test_passed
-        template = Crinja.render(cpu_chaos_template, { "labels" => KubectlClient::Get.deployment_spec_labels(deployment_name).as_h })
+        template = Crinja.render(cpu_chaos_template, { "labels" => KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h })
         chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/chaos_cpu_hog.yml"`
         VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_cpu_hog.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
         # TODO fail if exceeds
         if wait_for_test("StressChaos", "burn-cpu")
-          unless desired_is_available?(deployment_name)
+          unless KubectlClient::Get.resource_desired_is_available?(resource["kind"], resource["name"])
             test_passed = false
-            puts "Chaosmesh Application pod is not healthy after high CPU consumption for deployment: #{deployment_name}".colorize(:red)
+            puts "Chaosmesh Application pod is not healthy after high CPU consumption for resource: #{resource["name"]}".colorize(:red)
           end
         else
           # TODO Change this to an exception (points = 0)
           # e.g. upsert_exception_task
             test_passed = false
-            puts "Chaosmesh failed to finish for deployment: #{deployment_name}".colorize(:red)
-          # resp = upsert_failed_task("chaos_cpu_hog","✖️  FAILURE: Chaosmesh failed to finish.")
+            puts "Chaosmesh failed to finish for resource: #{resource["name"]}".colorize(:red)
         end
       end
     end
-    if test_passed
+    if task_response 
       resp = upsert_passed_task("chaos_cpu_hog","✔️  PASSED: Application pod is healthy after high CPU consumption #{emoji_chaos_cpu_hog}")
     else
       resp = upsert_failed_task("chaos_cpu_hog","✖️  FAILURE: Application pod is not healthy after high CPU consumption #{emoji_chaos_cpu_hog}")
@@ -159,79 +106,55 @@ end
 
 desc "Does the CNF recover when its container is killed"
 task "chaos_container_kill", ["install_chaosmesh", "retrieve_manifest"] do |_, args|
-  task_response = task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "chaos_container_kill" if check_verbose(args)
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    helm_directory = "#{config.get("helm_directory").as_s?}"
-    manifest_directory = optional_key_as_string(config, "manifest_directory")
-    release_name = "#{config.get("release_name").as_s?}"
-    helm_chart_path = destination_cnf_dir + "/" + helm_directory
-    manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
-    LOGGING.debug "#{destination_cnf_dir}"
-    LOGGING.info "destination_cnf_dir #{destination_cnf_dir}"
+    LOGGING.debug "cnf_config: #{config}"
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     emoji_chaos_container_kill="🗡️💀♻️"
+    resource_names = [] of Hash(String, String)
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
-    if release_name.empty? # no helm chart
-      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-    else
-      Helm.generate_manifest_from_templates(release_name, 
-                                          helm_chart_path, 
-                                          manifest_file_path)
-      template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
-    end
-
-    deployment_ymls = Helm.workload_resource_by_kind(template_ymls, Helm::DEPLOYMENT)
-    deployment_names = Helm.workload_resource_names(deployment_ymls)
-    LOGGING.info "deployment names: #{deployment_names}"
-    if deployment_names && deployment_names.size > 0 
-      test_passed = true
-    else
-        puts "No deployment names found for container kill test".colorize(:red)
-      test_passed = false
-    end
-    deployment_names.each do | deployment_name |
-
-      if KubectlClient::Get.deployment_spec_labels(deployment_name).as_h? && KubectlClient::Get.deployment_spec_labels(deployment_name).as_h.size > 0
+      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && 
+          KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.size > 0
         test_passed = true
       else
-        puts "No deployment label found for container kill test for deployment: #{deployment_name}".colorize(:red)
+        puts "No resource label found for container kill test for resource: #{resource}".colorize(:red)
         test_passed = false
       end
       if test_passed
-        containers = KubectlClient::Get.deployment_containers(deployment_name)
-        containers.as_a.each do |container|
-          # TODO change helm_chart_container_name to container_name
-          template = Crinja.render(chaos_template_container_kill, { "labels" => KubectlClient::Get.deployment_spec_labels(deployment_name).as_h, "helm_chart_container_name" => "#{container.as_h["name"]}" })
-          LOGGING.debug "chaos template: #{template}"
-          chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/chaos_container_kill.yml"`
-          VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
-          run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_container_kill.yml"`
-          VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
-          if wait_for_test("PodChaos", "container-kill")
-            CNFManager.wait_for_install(deployment_name, wait_count=60)
-          else
-            # TODO Change this to an exception (points = 0)
-            # e.g. upsert_exception_task
-            test_passed = false
-            puts "Chaosmesh chaos_container_kill failed to finish for deployment: #{deployment_name} and container: #{container.as_h["name"].as_s}".colorize(:red)
-          end
+        # TODO change helm_chart_container_name to container_name
+        template = Crinja.render(chaos_template_container_kill, { "labels" => KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h, "helm_chart_container_name" => "#{container.as_h["name"]}" })
+        LOGGING.debug "chaos template: #{template}"
+        chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/chaos_container_kill.yml"`
+        VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
+        run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_container_kill.yml"`
+        VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
+        if wait_for_test("PodChaos", "container-kill")
+          CNFManager.wait_for_install(resource["name"], wait_count=60)
+        else
+          # TODO Change this to an exception (points = 0)
+          # e.g. upsert_exception_task
+          test_passed = false
+          puts "Chaosmesh chaos_container_kill failed to finish forresource: #{resource} and container: #{container.as_h["name"].as_s}".colorize(:red)
         end
-        # TODO fail if exceeds
-        # if wait_for_test("PodChaos", "container-kill")
-        # CNFManager.wait_for_install(deployment_name, wait_count=60)
+      end
+      # TODO fail if exceeds
+      # if wait_for_test("PodChaos", "container-kill")
+      # CNFManager.wait_for_install(deployment_name, wait_count=60)
 
+      resource_names << {"kind" => resource["kind"].as_s,
+                         "name" => resource["name"].as_s}
+      test_passed
+    end
+    desired_passed = resource_names.map do |x| 
+      if KubectlClient::Get.resource_desired_is_available?(x["kind"], x["name"])
+        true
+      else
+        puts "Replicas did not return desired count after container kill test for deployment: #{x}".colorize(:red)
+        false
       end
     end
-    desired_passed = deployment_names.map do |x| 
-     if desired_is_available?(x)
-       true
-     else
-       puts "Replicas did not return desired count after container kill test for deployment: #{x}".colorize(:red)
-       false
-     end
-    end
-    if test_passed && desired_passed.all?
+    if task_response && desired_passed.all?
       resp = upsert_passed_task("chaos_container_kill","✔️  PASSED: Replicas available match desired count after container kill test #{emoji_chaos_container_kill}")
     else
       resp = upsert_failed_task("chaos_container_kill","✖️  FAILURE: Replicas did not return desired count after container kill test #{emoji_chaos_container_kill}")

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -21,8 +21,8 @@ task "chaos_network_loss", ["install_chaosmesh", "retrieve_manifest"] do |_, arg
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
-      if KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h? && 
-          KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h.size > 0
+      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && 
+          KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.size > 0
         test_passed = true
       else
         puts "No resource label found for container kill test for resource: #{resource}".colorize(:red)
@@ -68,7 +68,7 @@ task "chaos_cpu_hog", ["install_chaosmesh", "retrieve_manifest"] do |_, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     emoji_chaos_cpu_hog="📦💻🐷📈"
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && KubectlClient::Get.deployment_spec_labels(resource["name"]).as_h.size > 0
+      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.size > 0
         test_passed = true
       else
         puts "No resource label found for container kill test for resource: #{resource["name"]}".colorize(:red)
@@ -150,7 +150,7 @@ task "chaos_container_kill", ["install_chaosmesh", "retrieve_manifest"] do |_, a
       if KubectlClient::Get.resource_desired_is_available?(x["kind"], x["name"])
         true
       else
-        puts "Replicas did not return desired count after container kill test for deployment: #{x}".colorize(:red)
+        puts "Replicas did not return desired count after container kill test for resource: #{x}".colorize(:red)
         false
       end
     end

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -130,7 +130,8 @@ task "chaos_container_kill", ["install_chaosmesh", "retrieve_manifest"] do |_, a
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_container_kill.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
         if wait_for_test("PodChaos", "container-kill")
-          CNFManager.wait_for_install(resource["name"], wait_count=60)
+          # CNFManager.wait_for_install(resource["name"], wait_count=60)
+          CNFManager.resource_wait_for_install(resource["kind"], resource["name"], wait_count=60)
         else
           # TODO Change this to an exception (points = 0)
           # e.g. upsert_exception_task

--- a/src/tasks/workload/scalability.cr
+++ b/src/tasks/workload/scalability.cr
@@ -82,17 +82,7 @@ def change_capacity(base_replicas, target_replica_count, args, config, resource 
   VERBOSE_LOGGING.info "base replicas: #{base_replicas}" if check_verbose(args)
   LOGGING.debug "resource: #{resource}"
 
-  # Parse the cnf-conformance.yml
-  # config = cnf_conformance_yml
-    # helm_directory = config.cnf_config[:helm_directory]
-  # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-
   initialization_time = base_replicas.to_i * 10
-  # if args.named.keys.includes? "resource"
-  #   resource = args.named["resource"]
-  # else
-  #   resource = config.get("resource").as_s 
-  # end
   VERBOSE_LOGGING.info "resource: #{resource["metadata"]["name"]}" if check_verbose(args)
 
   #TODO use kubectl scale command that is specific to the kind

--- a/src/tasks/workload/scalability.cr
+++ b/src/tasks/workload/scalability.cr
@@ -22,14 +22,24 @@ end
 
 desc "Test increasing capacity by setting replicas to 1 and then increasing to 3"
 task "increase_capacity" do |_, args|
-  task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "increase_capacity" if check_verbose(args)
     emoji_increase_capacity="📦📈"
 
     target_replicas = "3"
     base_replicas = "1"
-    final_count = change_capacity(base_replicas, target_replicas, args)
-    if target_replicas == final_count 
+    task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
+      if resource["kind"].as_s.downcase == "deployment" ||
+          resource["kind"].as_s.downcase == "statefulset" ||
+          resource["kind"].as_s.downcase == "replicaset"
+        final_count = change_capacity(base_replicas, target_replicas, args, config, resource)
+        target_replicas == final_count
+      else
+        true
+      end
+    end
+    # if target_replicas == final_count 
+    if task_response.none?(false) 
       upsert_passed_task("increase_capacity", "✔️  PASSED: Replicas increased to #{target_replicas} #{emoji_increase_capacity}")
     else
       upsert_failed_task("increase_capacity", "✖️  FAILURE: Replicas did not reach #{target_replicas} #{emoji_increase_capacity}")
@@ -39,14 +49,24 @@ end
 
 desc "Test decrease capacity by setting replicas to 3 and then decreasing to 1"
 task "decrease_capacity" do |_, args|
-  task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "decrease_capacity" if check_verbose(args)
     target_replicas = "1"
     base_replicas = "3"
-    final_count = change_capacity(base_replicas, target_replicas, args)
+    task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
+      if resource["kind"].as_s.downcase == "deployment" ||
+          resource["kind"].as_s.downcase == "statefulset" ||
+          resource["kind"].as_s.downcase == "replicaset"
+        final_count = change_capacity(base_replicas, target_replicas, args, config, resource)
+        target_replicas == final_count
+      else
+        true
+      end
+    end
     emoji_decrease_capacity="📦📉"
 
-    if target_replicas == final_count 
+    # if target_replicas == final_count 
+    if task_response.none?(false) 
       upsert_passed_task("decrease_capacity", "✔️  PASSED: Replicas decreased to #{target_replicas} #{emoji_decrease_capacity}")
     else
       upsert_failed_task("decrease_capacity", "✖️  FAILURE: Replicas did not reach #{target_replicas} #{emoji_decrease_capacity}")
@@ -54,39 +74,54 @@ task "decrease_capacity" do |_, args|
   end
 end
 
-def change_capacity(base_replicas, target_replica_count, args)
+def change_capacity(base_replicas, target_replica_count, args, config, resource = {kind: "", 
+                                                                                   metadata: {name: ""}})
   VERBOSE_LOGGING.info "change_capacity" if check_verbose(args)
   VERBOSE_LOGGING.debug "increase_capacity args.raw: #{args.raw}" if check_verbose(args)
   VERBOSE_LOGGING.debug "increase_capacity args.named: #{args.named}" if check_verbose(args)
   VERBOSE_LOGGING.info "base replicas: #{base_replicas}" if check_verbose(args)
+  LOGGING.debug "resource: #{resource}"
 
   # Parse the cnf-conformance.yml
   # config = cnf_conformance_yml
-  config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
+    # helm_directory = config.cnf_config[:helm_directory]
+  # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
 
   initialization_time = base_replicas.to_i * 10
-  if args.named.keys.includes? "deployment_name"
-    deployment_name = args.named["deployment_name"]
-  else
-    deployment_name = config.get("deployment_name").as_s 
-  end
-  VERBOSE_LOGGING.info "deployment_name: #{deployment_name}" if check_verbose(args)
+  # if args.named.keys.includes? "resource"
+  #   resource = args.named["resource"]
+  # else
+  #   resource = config.get("resource").as_s 
+  # end
+  VERBOSE_LOGGING.info "resource: #{resource["metadata"]["name"]}" if check_verbose(args)
 
-  base = `kubectl scale deployment.v1.apps/#{deployment_name} --replicas=#{base_replicas}`
+  #TODO use kubectl scale command that is specific to the kind
+  case resource["kind"]
+  when "deployment"
+    LOGGING.debug "kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{base_replicas}"
+
+    base = `kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{base_replicas}`
+  else
+    LOGGING.debug "kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{base_replicas}"
+
+    base = `kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{base_replicas}`
+  end
   VERBOSE_LOGGING.info "base: #{base}" if check_verbose(args) 
-  initialized_count = wait_for_scaling(deployment_name, base_replicas, args)
+  initialized_count = wait_for_scaling(resource, base_replicas, args)
   if initialized_count != base_replicas
-    VERBOSE_LOGGING.info "deployment initialized to #{initialized_count} and could not be set to #{base_replicas}" if check_verbose(args)
+    VERBOSE_LOGGING.info "#{resource["kind"]} initialized to #{initialized_count} and could not be set to #{base_replicas}" if check_verbose(args)
   else
-    VERBOSE_LOGGING.info "deployment initialized to #{initialized_count}" if check_verbose(args)
+    VERBOSE_LOGGING.info "#{resource["kind"]} initialized to #{initialized_count}" if check_verbose(args)
   end
-
-  increase = `kubectl scale deployment.v1.apps/#{deployment_name} --replicas=#{target_replica_count}`
-  current_replicas = wait_for_scaling(deployment_name, target_replica_count, args)
+ 
+  LOGGING.debug "kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{target_replica_count}"
+  #TODO use kubectl scale command that is specific to the kind
+  increase = `kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{target_replica_count}`
+  current_replicas = wait_for_scaling(resource, target_replica_count, args)
   current_replicas
 end
 
-def wait_for_scaling(deployment_name, target_replica_count, args)
+def wait_for_scaling(resource, target_replica_count, args)
   VERBOSE_LOGGING.info "target_replica_count: #{target_replica_count}" if check_verbose(args)
   if args.named.keys.includes? "wait_count"
     wait_count_value = args.named["wait_count"]
@@ -96,15 +131,15 @@ def wait_for_scaling(deployment_name, target_replica_count, args)
   wait_count = wait_count_value.to_i
   second_count = 0
   current_replicas = "0"
-  previous_replicas = `kubectl get deployments #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
+  previous_replicas = `kubectl get #{resource["kind"]} #{resource["metadata"]["name"]} -o=jsonpath='{.status.readyReplicas}'`
   until current_replicas == target_replica_count || second_count > wait_count
     VERBOSE_LOGGING.debug "secound_count: #{second_count} wait_count: #{wait_count}" if check_verbose(args)
-    VERBOSE_LOGGING.info "current_replicas before get deployments: #{current_replicas}" if check_verbose(args)
+    VERBOSE_LOGGING.info "current_replicas before get #{resource["kind"]}: #{current_replicas}" if check_verbose(args)
     sleep 1
     VERBOSE_LOGGING.debug `echo $KUBECONFIG` if check_verbose(args)
-    VERBOSE_LOGGING.info "Get deployments command: kubectl get deployments #{deployment_name} -o=jsonpath='{.status.readyReplicas}'" if check_verbose(args)
-    current_replicas = `kubectl get deployments #{deployment_name} -o=jsonpath='{.status.readyReplicas}'`
-    VERBOSE_LOGGING.info "current_replicas after get deployments: #{current_replicas.inspect}" if check_verbose(args)
+    VERBOSE_LOGGING.info "Get #{resource["kind"]} command: kubectl get #{resource["kind"]} #{resource["metadata"]["name"]} -o=jsonpath='{.status.readyReplicas}'" if check_verbose(args)
+    current_replicas = `kubectl get #{resource["kind"]} #{resource["metadata"]["name"]} -o=jsonpath='{.status.readyReplicas}'`
+    VERBOSE_LOGGING.info "current_replicas after get #{resource["kind"]}: #{current_replicas.inspect}" if check_verbose(args)
 
     if current_replicas.empty?
       current_replicas = "0"

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -14,57 +14,31 @@ task "privileged" do |_, args|
   #TODO Document all arguments
   #TODO check if container exists
   #TODO Check if args exist
-  task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "privileged" if check_verbose(args)
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    helm_directory = "#{config.get("helm_directory").as_s?}"
-    manifest_directory = optional_key_as_string(config, "manifest_directory")
-    release_name = "#{config.get("release_name").as_s?}"
-    helm_chart_path = destination_cnf_dir + "/" + helm_directory
-    manifest_file_path = destination_cnf_dir + "/" + "temp_template.yml"
+    white_list_container_names = config.cnf_config[:white_list_container_names]
+    VERBOSE_LOGGING.info "white_list_container_names #{white_list_container_names.inspect}" if check_verbose(args)
+    violation_list = [] of String
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
-    if release_name.empty? # no helm chart
-      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-    else
-      Helm.generate_manifest_from_templates(release_name, 
-                                          helm_chart_path, 
-                                          manifest_file_path)
-      template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path) 
-    end
-
-    deployment_ymls = Helm.workload_resource_by_kind(template_ymls, Helm::DEPLOYMENT)
-    deployment_names = Helm.workload_resource_names(deployment_ymls)
-    LOGGING.info "deployment names: #{deployment_names}"
-    if deployment_names && deployment_names.size > 0 
-      test_passed = true
-    else
-      puts "No deployment names found for container kill test".colorize(:red)
-    end
-
-    containers = deployment_names.map { | deployment_name |
-      KubectlClient::Get.deployment_containers(deployment_name).as_a.map do |c|
-        c["name"]
+      privileged_list = KubectlClient::Get.privileged_containers
+      white_list_containers = ((PRIVILEGED_WHITELIST_CONTAINERS + white_list_container_names) - [container])
+      # Only check the containers that are in the deployed helm chart or manifest
+      (privileged_list & ([container.as_h["name"].as_s] - white_list_containers)).each do |x|
+        violation_list << x
       end
-    }.flatten  
-
-    white_list_container_name = config.get("white_list_helm_chart_container_names").as_a
-    VERBOSE_LOGGING.info "white_list_container_name #{white_list_container_name.inspect}" if check_verbose(args)
-    VERBOSE_LOGGING.info "installed container names #{containers.inspect}" if check_verbose(args)
-
-    privileged_list = KubectlClient::Get.privileged_containers
-    white_list_containers = ((PRIVILEGED_WHITELIST_CONTAINERS + white_list_container_name) - [containers])
-    # Only check the containers that are in the deployed helm chart or manifest
-    violation_list = privileged_list & (containers - white_list_containers)
-    LOGGING.info "violator list: #{violation_list}"
+      if violation_list.size > 0
+        false
+      else
+        true
+      end
+    end
+    LOGGING.debug "violator list: #{violation_list.flatten}"
     emoji_security="🔓🔑"
-    # TODO use list of names in containers variable
-    # if privileged_list.find {|x| x == helm_chart_container_name} ||
-    #     violation_list.size > 0
-    if violation_list.size > 0
-      upsert_failed_task("privileged", "✖️  FAILURE: Found #{violation_list.size} privileged containers: #{violation_list.inspect} #{emoji_security}")
-    else
+    if task_response 
       upsert_passed_task("privileged", "✔️  PASSED: No privileged containers #{emoji_security}")
+    else
+      upsert_failed_task("privileged", "✖️  FAILURE: Found #{violation_list.size} privileged containers: #{violation_list.inspect} #{emoji_security}")
     end
   end
 end

--- a/src/tasks/workload/statelessness.cr
+++ b/src/tasks/workload/statelessness.cr
@@ -19,35 +19,32 @@ task "volume_hostpath_not_found", ["retrieve_manifest"] do |_, args|
     passed_emoji = "🖥️  💾"
     LOGGING.debug "cnf_config: #{config}"
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
-    # config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    # destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    # TODO loop through all deployments
-    deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
-    # VERBOSE_LOGGING.info deployment.inspect if check_verbose(args)
-    # TODO use new workload_yml function
-    task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource|
-
+    task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
       hostPath_found = nil 
       begin
         # TODO check to see if this fails with container storage (and then erroneously fails the test as having hostpath volumes)
-        volumes = deployment.get("spec").as_h["template"].as_h["spec"].as_h["volumes"].as_a
-        hostPath_not_found = volumes.none? do |volume| 
-          if volume.as_h["hostPath"]?
-              true
+        volumes = resource.dig?("spec", "template", "spec", "volumes")
+        if volumes
+          hostPath_not_found = volumes.as_a.none? do |volume| 
+            if volume.as_h["hostPath"]?
+                true
+            end
           end
+        else
+          hostPath_not_found = true
         end
       rescue ex
         VERBOSE_LOGGING.error ex.message if check_verbose(args)
-        puts "✖️  FAILURE: On resource #{deployment}, hostPath volumes found #{failed_emoji}".colorize(:red)
+        puts "Rescued: On resource #{resource["metadata"]["name"]?} of kind #{resource["kind"]}, volumes not found. #{passed_emoji}".colorize(:yellow)
         hostPath_not_found = true
       end
       hostPath_not_found 
     end
 
-    if task_response
-      upsert_passed_task("volume_hostpath_not_found","✔️  PASSED: hostPath volumes not found #{passed_emoji}")
-    else
+    if task_response.any?(false)
       upsert_failed_task("volume_hostpath_not_found","✖️  FAILURE: hostPath volumes found #{failed_emoji}")
+    else
+      upsert_passed_task("volume_hostpath_not_found","✔️  PASSED: hostPath volumes not found #{passed_emoji}")
     end
   end
 end
@@ -56,58 +53,59 @@ desc "Does the CNF use a non-cloud native data store: local volumes on the node?
 task "no_local_volume_configuration", ["retrieve_manifest"] do |_, args|
   failed_emoji = "(ভ_ভ) ރ 💾"
   passed_emoji = "🖥️  💾"
-  task_response = task_runner(args) do |args|
+  task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "no_local_volume_configuration" if check_verbose(args)
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
-    destination_cnf_dir = CNFManager.cnf_destination_dir(CNFManager.ensure_cnf_conformance_dir(args.named["cnf-config"].as(String)))
-    # TODO get manifest from constant or args
-    deployment = Totem.from_file "#{destination_cnf_dir}/manifest.yml"
-    VERBOSE_LOGGING.info deployment.inspect if check_verbose(args)
 
-    hostPath_found = nil 
-    begin
-      # Note: A storageClassName value of "local-storage" is insufficient to determine if the
-      # persistent volume is indeed local storage.  This is because the storageClass can be redefined
-      # to be anything (e.g. the name local-storage can be redefined to be block storage behind the scenes) 
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
+    task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
+      hostPath_found = nil 
+      begin
+        # Note: A storageClassName value of "local-storage" is insufficient to determine if the
+        # persistent volume is indeed local storage.  This is because the storageClass can be redefined
+        # to be anything (e.g. the name local-storage can be redefined to be block storage behind the scenes) 
 
-      volumes = [] of Totem::Any
-      if deployment.get("spec").as_h["template"].as_h["spec"].as_h["volumes"]?
-        volumes = deployment.get("spec").as_h["template"].as_h["spec"].as_h["volumes"].as_a 
-      end
-      LOGGING.debug "volumes: #{volumes}"
-      persistent_volume_claim_names = volumes.map do |volume|
-        # get persistent volume claim that matches persistent volume claim name
-        if volume.as_h["persistentVolumeClaim"]? && volume.as_h["persistentVolumeClaim"].as_h["claimName"]?
-            volume.as_h["persistentVolumeClaim"].as_h["claimName"]
+        volumes = [] of YAML::Any
+        if resource["spec"].as_h["template"].as_h["spec"].as_h["volumes"]?
+            volumes = resource["spec"].as_h["template"].as_h["spec"].as_h["volumes"].as_a 
+        end
+        LOGGING.debug "volumes: #{volumes}"
+        persistent_volume_claim_names = volumes.map do |volume|
+          # get persistent volume claim that matches persistent volume claim name
+          if volume.as_h["persistentVolumeClaim"]? && volume.as_h["persistentVolumeClaim"].as_h["claimName"]?
+              volume.as_h["persistentVolumeClaim"].as_h["claimName"]
           else
             nil 
           end
-      end.compact
-      LOGGING.debug "persistent volume claim names: #{persistent_volume_claim_names}"
+        end.compact
+        LOGGING.debug "persistent volume claim names: #{persistent_volume_claim_names}"
 
-      # TODO (optional) check storage class of persistent volume claim
-      # loop through all pvc names
-      # get persistent volume that matches pvc name
-      # get all items, get spec, get claimRef, get pvc name that matches pvc name 
-      local_storage_found = false
-      persistent_volume_claim_names.map do | claim_name|
-        items = KubectlClient::Get.pv_items_by_claim_name(claim_name)
-        items.map do |item|
-          begin
-          if item["spec"]["local"]? && item["spec"]["local"]["path"]?
-              local_storage_found = true
-          end
-          rescue ex
-            LOGGING.info ex.message 
+        # TODO (optional) check storage class of persistent volume claim
+        # loop through all pvc names
+        # get persistent volume that matches pvc name
+        # get all items, get spec, get claimRef, get pvc name that matches pvc name 
+        local_storage_not_found = true 
+        persistent_volume_claim_names.map do | claim_name|
+          items = KubectlClient::Get.pv_items_by_claim_name(claim_name)
+          items.map do |item|
+            begin
+              if item["spec"]["local"]? && item["spec"]["local"]["path"]?
+                  local_storage_not_found = false 
+              end
+            rescue ex
+              LOGGING.info ex.message 
+              local_storage_not_found = true 
+            end
           end
         end
+      rescue ex
+        VERBOSE_LOGGING.error ex.message if check_verbose(args)
+        puts "Rescued: On resource #{resource["metadata"]["name"]?} of kind #{resource["kind"]}, local storage configuration volumes not found #{passed_emoji}".colorize(:yellow)
+        local_storage_not_found = true
       end
-    rescue ex
-      VERBOSE_LOGGING.error ex.message if check_verbose(args)
-      upsert_passed_task("no_local_volume_configuration","✔️  PASSED: local storage configuration volumes not found #{passed_emoji}")
+      local_storage_not_found
     end
 
-    if local_storage_found 
+    if task_response.any?(false) 
       upsert_failed_task("no_local_volume_configuration","✖️  FAILURE: local storage configuration volumes found #{failed_emoji}")
     else
       upsert_passed_task("no_local_volume_configuration","✔️  PASSED: local storage configuration volumes not found #{passed_emoji}")

--- a/src/tasks/workload/statelessness.cr
+++ b/src/tasks/workload/statelessness.cr
@@ -31,7 +31,7 @@ task "volume_hostpath_not_found", ["retrieve_manifest"] do |_, args|
       begin
         # TODO check to see if this fails with container storage (and then erroneously fails the test as having hostpath volumes)
         volumes = deployment.get("spec").as_h["template"].as_h["spec"].as_h["volumes"].as_a
-        hostPath_found = volumes.find do |volume| 
+        hostPath_not_found = volumes.none? do |volume| 
           if volume.as_h["hostPath"]?
               true
           end
@@ -39,14 +39,15 @@ task "volume_hostpath_not_found", ["retrieve_manifest"] do |_, args|
       rescue ex
         VERBOSE_LOGGING.error ex.message if check_verbose(args)
         puts "✖️  FAILURE: On resource #{deployment}, hostPath volumes found #{failed_emoji}".colorize(:red)
-        false
+        hostPath_not_found = true
       end
+      hostPath_not_found 
     end
 
     if task_response
-      upsert_failed_task("volume_hostpath_not_found","✖️  FAILURE: hostPath volumes found #{failed_emoji}")
-    else
       upsert_passed_task("volume_hostpath_not_found","✔️  PASSED: hostPath volumes not found #{passed_emoji}")
+    else
+      upsert_failed_task("volume_hostpath_not_found","✖️  FAILURE: hostPath volumes found #{failed_emoji}")
     end
   end
 end


### PR DESCRIPTION
# Add support for additional K8s workload resource kinds: Pod, ReplicaSet, StatefulSet, Daemonset #531

## Description
Add support for additional K8s workload resource kinds: Pod, ReplicaSet, StatefulSet, Daemonset #531

## Issues:
Refs: #531

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
