### PR TITLE
[Enhancement] Add existing destructive flag to the `reasonable_startup_time` and `helm_deploy` tests #562

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -224,7 +224,7 @@ crystal src/cnf-conformance.cr protected_access
 ```
 #### :heavy_check_mark: To check if the CNF have a reasonable startup time
 ```
-./cnf-conformance reasonable_startup_time
+./cnf-conformance reasonable_startup_time destructive
 ```
 
 ---
@@ -396,7 +396,7 @@ cp -rf <your-cnf-directory> cnfs/<your-cnf-directory>
 ```
 Now run the test:
 ```
-./cnf-conformance helm_deploy cnfs/<your-cnf-directory>/cnf-conformance.yml
+./cnf-conformance helm_deploy destructive cnfs/<your-cnf-directory>/cnf-conformance.yml
 ```
 #### :heavy_check_mark: Test if the install script uses [Helm v3](https://github.com/helm/)
 ```

--- a/spec/cnf_conformance_all/cnf_conformance_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_spec.cr
@@ -27,7 +27,7 @@ describe CnfConformance do
     (/PASSED: Published Helm Chart Found/ =~ response_s).should_not be_nil
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil
-    (all_result_test_names(CNFManager.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published","helm_deploy", "reasonable_image_size", "reasonable_startup_time", "rollback" ].sort)
+    (all_result_test_names(CNFManager.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published", "reasonable_image_size", "rollback" ].sort)
     (/^.*\.cr:[0-9].*/ =~ response_s).should be_nil
     $?.success?.should be_true
   end

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -361,7 +361,7 @@ describe "Utils" do
   end
 
   it "'logger' or verbose output should be shown when verbose flag is set", tags: ["logger"] do
-    response_s = `./cnf-conformance helm_deploy verbose`
+    response_s = `./cnf-conformance helm_deploy destructive verbose`
     LOGGING.info response_s
     puts response_s
     $?.success?.should be_true

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -19,28 +19,28 @@ describe CnfConformance do
   end
 
 	it "'helm_deploy' should fail on a bad helm chart", tags: "helm" do
-    response_s = `./cnf-conformance helm_deploy cnf-config=sample-cnfs/sample-bad-helm-deploy-repo/cnf-conformance.yml verbose`
+    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample-bad-helm-deploy-repo/cnf-conformance.yml verbose`
     LOGGING.info response_s
     $?.success?.should be_true
     (/FAILURE: Helm deploy failed/ =~ response_s).should_not be_nil
   end
 
   it "'helm_deploy' should fail if command is not supplied cnf-config argument", tags: "helm" do
-    response_s = `./cnf-conformance helm_deploy`
+    response_s = `./cnf-conformance helm_deploy destructive`
     LOGGING.info response_s
     $?.success?.should be_true
     (/No cnf_conformance.yml found! Did you run the setup task/ =~ response_s).should_not be_nil
   end
 
   it "'helm_deploy' should pass if command is supplied cnf-config argument with helm_chart declared", tags: ["helm", "happy-path"]  do
-    response_s = `./cnf-conformance helm_deploy cnf-config=sample-cnfs/sample_coredns/cnf-conformance.yml verbose`
+    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample_coredns/cnf-conformance.yml verbose`
     $?.success?.should be_true
     LOGGING.info response_s
     (/PASSED: Helm deploy successful/ =~ response_s).should_not be_nil
   end
 
   it "'helm_deploy' should pass if command is supplied cnf-config argument without helm_chart declared", tags: ["helm", "happy-path"]  do
-    response_s = `./cnf-conformance helm_deploy cnf-config=sample-cnfs/sample_coredns_chart_directory/cnf-conformance.yml verbose`
+    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample_coredns_chart_directory/cnf-conformance.yml verbose`
     $?.success?.should be_true
     LOGGING.info response_s
     (/PASSED: Helm deploy successful/ =~ response_s).should_not be_nil

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -18,7 +18,7 @@ describe "Microservice" do
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time", "happy-path"]  do
     begin
-      response_s = `./cnf-conformance reasonable_startup_time cnf-config=sample-cnfs/sample_coredns/cnf-conformance.yml`
+      response_s = `./cnf-conformance reasonable_startup_time destructive cnf-config=sample-cnfs/sample_coredns/cnf-conformance.yml`
       LOGGING.info response_s
       $?.success?.should be_true
       (/PASSED: CNF had a reasonable startup time/ =~ response_s).should_not be_nil
@@ -33,7 +33,7 @@ describe "Microservice" do
     `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-conformance.yml force=true`
       `kubectl delete -f sample-cnfs/sample_envoy_slow_startup/reasonable_startup_orig.yml`
     begin
-      response_s = `./cnf-conformance reasonable_startup_time cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-conformance.yml verbose`
+      response_s = `./cnf-conformance reasonable_startup_time  destructive cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-conformance.yml verbose`
       LOGGING.info response_s
       $?.success?.should be_true
       (/FAILURE: CNF had a startup time of/ =~ response_s).should_not be_nil

--- a/src/tasks/platform/resilience.cr
+++ b/src/tasks/platform/resilience.cr
@@ -22,8 +22,7 @@ namespace "platform" do
     LOGGING.info "Running POC in destructive mode!"
     task_response = task_runner(args) do |args|
       current_dir = FileUtils.pwd 
-      #helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
-    helm = CNFSingleton.helm
+      helm = CNFSingleton.helm
 
       #Select the first node that isn't a master and is also schedulable
       worker_nodes = `kubectl get nodes --selector='!node-role.kubernetes.io/master' -o 'go-template={{range .items}}{{$taints:=""}}{{range .spec.taints}}{{if eq .effect "NoSchedule"}}{{$taints = print $taints .key ","}}{{end}}{{end}}{{if not $taints}}{{.metadata.name}}{{ "\\n"}}{{end}}{{end}}'`

--- a/src/tasks/workload/installability.cr
+++ b/src/tasks/workload/installability.cr
@@ -12,6 +12,12 @@ end
 
 desc "Will the CNF install using helm with helm_deploy?"
 task "helm_deploy" do |_, args|
+  unless check_destructive(args)
+    LOGGING.info "skipping helm_deploy: not in destructive mode"
+    puts "Skipped".colorize(:yellow)
+    next
+  end
+  LOGGING.info "Running helm_deploy in destructive mode!"
   VERBOSE_LOGGING.info "helm_deploy" if check_verbose(args)
   LOGGING.info("helm_deploy args: #{args.inspect}")
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -15,6 +15,12 @@ end
 
 desc "Does the CNF have a reasonable startup time?"
 task "reasonable_startup_time" do |_, args|
+  unless check_destructive(args)
+    LOGGING.info "skipping reasonable_startup_time: not in destructive mode"
+    puts "Skipped".colorize(:yellow)
+    next
+  end
+  LOGGING.info "Running reasonable_startup_time in destructive mode!"
   task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "reasonable_startup_time" if check_verbose(args)
     LOGGING.debug "cnf_config: #{config.cnf_config}"


### PR DESCRIPTION
# [Enhancement] Add existing destructive flag to the `reasonable_startup_time` and `helm_deploy` tests #562

## Description
[Enhancement] Add existing destructive flag to the `reasonable_startup_time` and `helm_deploy` tests #562

## Issues:
Refs: #562

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
