### PR TITLE
[BUG] After running cnf_setup, cnf-conformance errors "you must provide cnf-config or cnf-path" when running tests after the setup. #572

### DIFF
--- a/spec/platform/platform_spec.cr
+++ b/spec/platform/platform_spec.cr
@@ -9,7 +9,7 @@ describe "Platform" do
     $?.success?.should be_true
     `./cnf-conformance setup`
     $?.success?.should be_true
-    # `./cnf-conformance sample_coredns_with_wait_setup`
+    # LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose`
     # $?.success?.should be_true
   end
   it "'platform:*' should not error out when no cnf is installed" do

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -14,7 +14,7 @@ describe "SampleUtils" do
   end
 
    # after_all do
-   #   LOGGING.debug `./cnf-conformance sample_coredns_setup`
+      # LOGGING.debug `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
    #   $?.success?.should be_true
    # end
 
@@ -24,7 +24,8 @@ describe "SampleUtils" do
   end
 
   it "'CNFManager.wait_for_install' should wait for a cnf to be installed", tags: "happy-path"  do
-    LOGGING.debug `./cnf-conformance sample_coredns_setup`
+    LOGGING.debug `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
+
     $?.success?.should be_true
 
     current_dir = FileUtils.pwd 

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -305,7 +305,9 @@ describe "SampleUtils" do
 
   it "'CNFManager.workload_resource_test' should accept an args and cnf-config argument, populate a deployment, container, and intialized argument, and then apply a test to a cnf"  do
     args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"])
-    check_cnf_config_then_deploy(args)
+    # check_cnf_config_then_deploy(args)
+    cli_hash = CNFManager.sample_setup_cli_args(args, false)
+    CNFManager.sample_setup(cli_hash) if cli_hash["config_file"]
     config = CNFManager::Config.parse_config_yml("./sample-cnfs/sample-generic-cnf/cnf-conformance.yml")    
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       test_passed = true

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -167,24 +167,26 @@ describe "Utils" do
     (check_cnf_config(args)).should eq("./sample-cnfs/sample-generic-cnf")
   end
 
-  it "'check_all_cnf_args' should return the value for a cnf-config argument"  do
-    args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"])
-    #TODO make CNFManager.sample_setup_args accept the full path to the config yml instead of the directory
-    (check_all_cnf_args(args)).should eq({"./sample-cnfs/sample-generic-cnf", true})
-  end
-  it "'check_cnf_config_then_deploy' should accept a cnf-config argument"  do
-    config_file = "./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"
-    args = Sam::Args.new(["cnf-config=#{config_file}"])
-    check_cnf_config_then_deploy(args)
-    config = CNFManager::Config.parse_config_yml(CNFManager.ensure_cnf_conformance_yml_path(config_file))    
-    release_name = config.cnf_config[:release_name]
-    CNFManager.cnf_config_list()[0].should contain("#{release_name}/#{CONFIG_FILE}")
-    CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-generic-cnf", verbose: true)
-  end
-
+  # it "'check_all_cnf_args' should return the value for a cnf-config argument"  do
+  #   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"])
+  #   #TODO make CNFManager.sample_setup_args accept the full path to the config yml instead of the directory
+  #   (check_all_cnf_args(args)).should eq({"./sample-cnfs/sample-generic-cnf", true})
+  # end
+  # it "'check_cnf_config_then_deploy' should accept a cnf-config argument"  do
+  #   config_file = "./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"
+  #   args = Sam::Args.new(["cnf-config=#{config_file}"])
+  #   check_cnf_config_then_deploy(args)
+  #   config = CNFManager::Config.parse_config_yml(CNFManager.ensure_cnf_conformance_yml_path(config_file))    
+  #   release_name = config.cnf_config[:release_name]
+  #   CNFManager.cnf_config_list()[0].should contain("#{release_name}/#{CONFIG_FILE}")
+  #   CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-generic-cnf", verbose: true)
+  # end
+  #
   it "'single_task_runner' should accept a cnf-config argument and apply a test to that cnf"  do
     args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml"])
-    check_cnf_config_then_deploy(args)
+    # check_cnf_config_then_deploy(args)
+    cli_hash = CNFManager.sample_setup_cli_args(args, false)
+    CNFManager.sample_setup(cli_hash) if cli_hash["config_file"]
     task_response = single_task_runner(args) do
       config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_conformance_yml_path(args.named["cnf-config"].as(String)))
       helm_chart_container_name = config.get("helm_chart_container_name").as_s

--- a/spec/workload/configuration_lifecycle_spec.cr
+++ b/spec/workload/configuration_lifecycle_spec.cr
@@ -17,7 +17,7 @@ describe CnfConformance do
 
   it "'ip_addresses' should pass when no uncommented ip addresses are found in helm chart source", tags: "happy-path"  do
     begin
-      `./cnf-conformance sample_coredns_source_setup verbose`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance ip_addresses verbose`
       LOGGING.info response_s

--- a/spec/workload/configuration_lifecycle_spec.cr
+++ b/spec/workload/configuration_lifecycle_spec.cr
@@ -41,7 +41,7 @@ describe CnfConformance do
   end
   it "'liveness' should fail when livenessProbe is not set", tags: "liveness" do
     begin
-      `./cnf-conformance sample_coredns_bad_liveness`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance liveness verbose`
       LOGGING.info response_s
@@ -65,7 +65,7 @@ describe CnfConformance do
   end
   it "'readiness' should fail when readinessProbe is not set", tags: "readiness" do
     begin
-      `./cnf-conformance sample_coredns_bad_liveness`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance readiness verbose`
       LOGGING.info response_s
@@ -80,7 +80,7 @@ describe CnfConformance do
   test_names.each do |tn|
     it "'#{tn}' should pass when valid version is given", tags: ["#{tn}", "happy-path"]  do
       begin
-        LOGGING.info `./cnf-conformance sample_coredns`
+        LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
         $?.success?.should be_true
         response_s = `./cnf-conformance rolling_update verbose`
         LOGGING.info response_s
@@ -106,7 +106,7 @@ describe CnfConformance do
 
   it "'rollback' should pass ", tags: ["rollback", "happy-path"]  do
     begin
-      LOGGING.info `./cnf-conformance sample_coredns`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance rollback verbose`
       LOGGING.info response_s
@@ -133,7 +133,7 @@ describe CnfConformance do
   end
   it "'nodeport_not_used' should pass when a node port is not being used", tags: "nodeport_not_used" do
     begin
-      `./cnf-conformance sample_coredns`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance nodeport_not_used verbose`
       LOGGING.info response_s
@@ -158,7 +158,7 @@ describe CnfConformance do
   end
   it "'hardcoded_ip_addresses_in_k8s_runtime_configuration' should pass when no ip addresses are found in the K8s configuration", tags: "hardcoded_ip_addresses_in_k8s_runtime_configuration" do
     begin
-      `./cnf-conformance sample_coredns`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance hardcoded_ip_addresses_in_k8s_runtime_configuration verbose`
       LOGGING.info response_s

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -62,7 +62,7 @@ describe CnfConformance do
     begin
       `./cnf-conformance sample_coredns_cleanup force=true`
       $?.success?.should be_true
-      `./cnf-conformance bad_helm_cnf_setup`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance helm_chart_valid`
       LOGGING.info response_s

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -48,11 +48,7 @@ describe CnfConformance do
 
 
   it "'helm_chart_valid' should pass on a good helm chart", tags: "happy-path"  do
-    # LOGGING.debug `pwd` 
-    # LOGGING.debug `echo $KUBECONFIG`
-    # `./cnf-conformance cleanup`
-    # $?.success?.should be_true
-    LOGGING.info `./cnf-conformance sample_coredns_setup`
+    LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
     $?.success?.should be_true
     response_s = `./cnf-conformance helm_chart_valid verbose`
     LOGGING.info response_s
@@ -74,7 +70,7 @@ describe CnfConformance do
       (/Lint Failed/ =~ response_s).should_not be_nil
     ensure
       `./cnf-conformance bad_helm_cnf_cleanup force=true`
-      `./cnf-conformance sample_coredns_setup`
+      `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
     end
   end
 

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -9,7 +9,7 @@ describe CnfConformance do
   end
 
   it "'install_script_helm' should fail if install script does not have helm", tags: "happy-path"  do
-    LOGGING.info `./cnf-conformance sample_coredns_source_setup`
+    LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml verbose wait_count=0`
     $?.success?.should be_true
     response_s =  `./cnf-conformance install_script_helm`
     LOGGING.info response_s

--- a/spec/workload/scalability_spec.cr
+++ b/spec/workload/scalability_spec.cr
@@ -17,7 +17,8 @@ it "'scalability' should run all of the scalability tests", tags: "happy-path"  
     `./cnf-conformance samples_cleanup`
     response_s = `./cnf-conformance setup`
     LOGGING.info response_s
-    `./cnf-conformance sample_coredns_with_wait_setup`
+    # `./cnf-conformance sample_coredns_with_wait_setup`
+    LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose`
     $?.success?.should be_true
     response_s = `./cnf-conformance scalability`
     LOGGING.info response_s

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -37,7 +37,7 @@ describe CnfConformance do
   end
   it "'privileged' should pass on a whitelisted, privileged cnf", tags: "privileged" do
     begin
-      `./cnf-conformance sample_privileged_cnf_whitelisted_setup`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance privileged cnf-config=sample-cnfs/sample_whitelisted_privileged_cnf verbose`
       LOGGING.info response_s

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -14,16 +14,12 @@ describe CnfConformance do
   end
   it "'privileged' should pass with a non-privileged cnf", tags: ["privileged", "happy-path"]  do
     begin
-      # `./cnf-conformance sample_coredns_setup`
-      # $?.success?.should be_true
-      # response_s = `./cnf-conformance privileged cnf-config=sample-cnfs/sample-coredns-cnf verbose`
       LOGGING.debug `./cnf-conformance cnf_setup cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml`
       response_s = `./cnf-conformance privileged verbose`
       LOGGING.info response_s
       $?.success?.should be_true
       (/Found.*privileged containers.*coredns/ =~ response_s).should be_nil
     ensure
-      # `./cnf-conformance sample_coredns_cleanup`
       LOGGING.debug `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-conformance.yml`
     end
   end

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -25,7 +25,7 @@ describe CnfConformance do
   end
   it "'privileged' should fail on a non-whitelisted, privileged cnf", tags: "privileged" do
     begin
-      `./cnf-conformance sample_privileged_cnf_non_whitelisted_setup`
+      LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-conformance privileged cnf-config=sample-cnfs/sample_privileged_cnf verbose`
       LOGGING.info response_s

--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -61,7 +61,7 @@ task "automatic_cnf_install" do |_, args|
   VERBOSE_LOGGING.info "all_prereqs" if check_verbose(args)
   # check_cnf_config_then_deploy(args)
   cli_hash = CNFManager.sample_setup_cli_args(args, false)
-  CNFManager.sample_setup(cli_hash) if cli_hash["config_file"]
+  CNFManager.sample_setup(cli_hash) if !cli_hash["config_file"].empty?
 end
 
 task "test" do

--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -25,7 +25,7 @@ task "all", ["workload", "platform"] do  |_, args|
 end
 
 desc "The CNF Conformance program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
-task "workload", ["all_prereqs", "configuration_file_setup", "compatibility","statelessness", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_and_scheduling", "microservice", "resilience"] do  |_, args|
+task "workload", ["automatic_cnf_install", "configuration_file_setup", "compatibility","statelessness", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_and_scheduling", "microservice", "resilience"] do  |_, args|
   VERBOSE_LOGGING.info "workload" if check_verbose(args)
 
   total = total_points("workload")
@@ -57,9 +57,11 @@ task "upsert_release" do |_, args|
   end
 end
 
-task "all_prereqs" do |_, args|
+task "automatic_cnf_install" do |_, args|
   VERBOSE_LOGGING.info "all_prereqs" if check_verbose(args)
-  check_cnf_config_then_deploy(args)
+  # check_cnf_config_then_deploy(args)
+  cli_hash = CNFManager.sample_setup_cli_args(args, false)
+  CNFManager.sample_setup(cli_hash) if cli_hash["config_file"]
 end
 
 task "test" do

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -30,55 +30,61 @@ require "./utils/utils.cr"
 #   CNFManager.sample_setup(cli_hash)
 # end
 
-desc "Sets up an alternate sample CoreDNS CNF"
-task "sample_coredns", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "sample_coredns new setup" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# desc "Sets up an alternate sample CoreDNS CNF"
+# task "sample_coredns", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "sample_coredns new setup" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-desc "Sets up a Bad helm CNF Setup"
-task "bad_helm_cnf_setup", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "bad_helm_cnf_setup" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-bad_helm_coredns-cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# desc "Sets up a Bad helm CNF Setup"
+# task "bad_helm_cnf_setup", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "bad_helm_cnf_setup" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-bad_helm_coredns-cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "sample_privileged_cnf_whitelisted_setup" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_whitelisted_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "sample_privileged_cnf_whitelisted_setup" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_whitelisted_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "sample_privileged_cnf_non_whitelisted_setup" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "sample_privileged_cnf_non_whitelisted_setup" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-task "sample_coredns_bad_liveness", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "sample_coredns_bad_liveness" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns_bad_liveness", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_coredns_bad_liveness", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "sample_coredns_bad_liveness" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns_bad_liveness", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-task "sample_generic_cnf_setup", ["helm_local_install"] do |_, args|
-  VERBOSE_LOGGING.info "sample_generic_cnf" if check_verbose(args)
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-generic-cnf", deploy_with_chart: false, args: args, verbose: true )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_generic_cnf_setup", ["helm_local_install"] do |_, args|
+#   VERBOSE_LOGGING.info "sample_generic_cnf" if check_verbose(args)
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-generic-cnf", deploy_with_chart: false, args: args, verbose: true )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
 task "cnf_setup", ["helm_local_install"] do |_, args|
   VERBOSE_LOGGING.info "cnf_setup" if check_verbose(args)

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -5,12 +5,13 @@ require "totem"
 require "./utils/utils.cr"
 
 desc "Sets up sample CoreDNS CNF"
-task "sample_coredns_setup", ["helm_local_install"] do |_, args|
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_coredns_setup", ["helm_local_install"] do |_, args|
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
+#       # response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
 task "sample_coredns_with_wait_setup", ["helm_local_install"] do |_, args|
   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true)

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -4,7 +4,7 @@ require "colorize"
 require "totem"
 require "./utils/utils.cr"
 
-desc "Sets up sample CoreDNS CNF"
+# desc "Sets up sample CoreDNS CNF"
 # task "sample_coredns_setup", ["helm_local_install"] do |_, args|
 #   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true, wait_count: 0 )
 #   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
@@ -13,20 +13,22 @@ desc "Sets up sample CoreDNS CNF"
 #   CNFManager.sample_setup(cli_hash)
 # end
 
-task "sample_coredns_with_wait_setup", ["helm_local_install"] do |_, args|
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true)
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# task "sample_coredns_with_wait_setup", ["helm_local_install"] do |_, args|
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true)
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose"])
+#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
-desc "Sets up sample CoreDNS CNF with source"
-task "sample_coredns_source_setup", ["helm_local_install"] do |_, args|
-  # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf-source", args: args, verbose: true, wait_count: 0 )
-  args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml", "verbose", "wait_count=0"])
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  CNFManager.sample_setup(cli_hash)
-end
+# desc "Sets up sample CoreDNS CNF with source"
+# task "sample_coredns_source_setup", ["helm_local_install"] do |_, args|
+#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf-source", args: args, verbose: true, wait_count: 0 )
+#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml", "verbose", "wait_count=0"])
+#    response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml verbose wait_count=0`
+#   cli_hash = CNFManager.sample_setup_cli_args(args)
+#   CNFManager.sample_setup(cli_hash)
+# end
 
 desc "Sets up an alternate sample CoreDNS CNF"
 task "sample_coredns", ["helm_local_install"] do |_, args|

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -169,6 +169,7 @@ module CNFManager
 
 
   def self.final_cnf_results_yml
+    LOGGING.info "final_cnf_results_yml" 
     results_file = `find ./results/* -name "cnf-conformance-results-*.yml"`.split("\n")[-2].gsub("./", "")
     if results_file.empty?
       raise "No cnf_conformance-results-*.yml found! Did you run the all task?"
@@ -199,6 +200,7 @@ module CNFManager
   end
 
   def self.sample_conformance_yml(sample_dir)
+    LOGGING.info "sample_conformance_yml sample_dir: #{sample_dir}"
     cnf_conformance = `find #{sample_dir}/* -name "cnf-conformance.yml"`.split("\n")[0]
     if cnf_conformance.empty?
       raise "No cnf_conformance.yml found in #{sample_dir}!"
@@ -583,7 +585,7 @@ module CNFManager
     end
   end
 
-  def self.sample_setup_cli_args(args)
+  def self.sample_setup_cli_args(args, noisy=true)
     VERBOSE_LOGGING.info "sample_setup_cli_args" if check_verbose(args)
     VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
     if args.named.keys.includes? "cnf-config"
@@ -591,9 +593,11 @@ module CNFManager
       cnf_path = File.dirname(yml_file)
     elsif args.named.keys.includes? "cnf-path"
       cnf_path = args.named["cnf-path"].as(String)
-    else
+    elsif noisy 
       stdout_failure "Error: You must supply either cnf-config or cnf-path"
       exit 1
+    else
+      cnf_path = ""
     end
     if args.named.keys.includes? "wait_count"
       wait_count = args.named["wait_count"].to_i

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -700,6 +700,7 @@ module CNFManager
 
   #sample_setup({config_file: cnf_path, wait_count: wait_count})
   def self.sample_setup(cli_args) 
+    LOGGING.info "sample_setup cli_args: #{cli_args}"
     config_file = cli_args[:config_file]
     wait_count = cli_args[:wait_count]
     verbose = cli_args[:verbose]

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -12,6 +12,8 @@ module CNFManager
       @cnf_config = cnf_config 
     end
     property cnf_config : NamedTuple(destination_cnf_dir: String,
+                                     source_cnf_file: String,
+                                     source_cnf_dir: String,
                                      yml_file_path: String,
                                      install_method: Tuple(Symbol, String),
                                      manifest_directory: String,
@@ -43,6 +45,8 @@ module CNFManager
       destination_cnf_dir = CNFManager.cnf_destination_dir(yml_file)
 
       yml_file_path = CNFManager.ensure_cnf_conformance_dir(config_yml_path)
+      source_cnf_file = yml_file
+      source_cnf_dir = yml_file_path
       manifest_directory = optional_key_as_string(config, "manifest_directory")
       helm_chart = optional_key_as_string(config, "helm_chart")
       release_name = "#{config.get("release_name").as_s?}"
@@ -73,6 +77,8 @@ module CNFManager
 
       # TODO populate nils with entries from cnf-conformance file
       CNFManager::Config.new({ destination_cnf_dir: destination_cnf_dir,
+                               source_cnf_file: source_cnf_file,
+                               source_cnf_dir: source_cnf_dir,
                                yml_file_path: yml_file_path,
                                install_method: install_method,
                                manifest_directory: manifest_directory,
@@ -602,8 +608,11 @@ module CNFManager
   # Create a unique directory for the cnf that is to be installed under ./cnfs
   # Only copy the cnf's cnf-conformance.yml and it's helm_directory or manifest directory (if it exists)
   # Use manifest directory if helm directory empty
-  def self.sandbox_setup(config_file, config, cli_args)
+  def self.sandbox_setup(config, cli_args)
+    LOGGING.info "sandbox_setup"
+    LOGGING.info "sandbox_setup config: #{config.cnf_config}"
     verbose = cli_args[:verbose]
+    config_file = config.cnf_config[:source_cnf_dir]
     release_name = config.cnf_config[:release_name]
     install_method = config.cnf_config[:install_method]
     helm_directory = config.cnf_config[:helm_directory]
@@ -647,8 +656,9 @@ module CNFManager
   end
 
   # Retrieve the helm chart source
-  def self.export_published_chart(config_file, config, cli_args)
+  def self.export_published_chart(config, cli_args)
     verbose = cli_args[:verbose]
+    config_file = config.cnf_config[:source_cnf_dir]
     helm_directory = config.cnf_config[:helm_directory]
     helm_chart = config.cnf_config[:helm_chart]
     destination_cnf_dir = CNFManager.cnf_destination_dir(config_file)
@@ -723,7 +733,7 @@ module CNFManager
     git_clone = `git clone #{git_clone_url} #{destination_cnf_dir}/#{release_name}`  if git_clone_url.empty? == false
     VERBOSE_LOGGING.info git_clone if verbose
 
-    sandbox_setup(config_file, config, cli_args)
+    sandbox_setup(config, cli_args)
 
     helm = CNFSingleton.helm
     LOGGING.info "helm path: #{CNFSingleton.helm}"
@@ -743,7 +753,7 @@ module CNFManager
       #TODO move to Helm module
       helm_install = `#{helm} install #{release_name} #{helm_chart}`
       VERBOSE_LOGGING.info helm_install if verbose 
-      export_published_chart(config_file, config, cli_args)
+      export_published_chart(config, cli_args)
     when :helm_directory
       VERBOSE_LOGGING.info "deploying with helm directory" if verbose 
       #TODO Add helm options into cnf-conformance yml

--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -33,13 +33,18 @@ module Helm
 
     def self.manifest_file_list(manifest_directory, silent=false)
       LOGGING.info("manifest_file_list")
-      LOGGING.info("find: find #{CNF_DIR}/* -name #{CONFIG_FILE}")
-      manifests = `find #{manifest_directory}/ -name "*.yml" -o -name "*.yaml"`.split("\n").select{|x| x.empty? == false}
-      LOGGING.info("find response: #{manifests}")
-      if manifests.size == 0 && !silent
-        raise "No manifest ymls found in the #{manifest_directory} directory!"
+      LOGGING.info "manifest_directory: #{manifest_directory}"
+      if manifest_directory && !manifest_directory.empty?
+        LOGGING.info("find: find #{manifest_directory}/ -name *.yml -o -name *.yaml")
+        manifests = `find #{manifest_directory}/ -name "*.yml" -o -name "*.yaml"`.split("\n").select{|x| x.empty? == false}
+        LOGGING.info("find response: #{manifests}")
+        if manifests.size == 0 && !silent
+          raise "No manifest ymls found in the #{manifest_directory} directory!"
+        end
+        manifests
+      else
+        [] of String
       end
-      manifests
     end
   end
 

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -62,23 +62,25 @@ def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | 
       config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
     else
       config = CNFManager::Config.new({ destination_cnf_dir: "",
-                               yml_file_path: "",
-                               install_method: {:helm_chart, ""},
-                               manifest_directory: "",
-                               helm_directory: "", 
-                               helm_chart_path: "", 
-                               manifest_file_path: "",
-                               git_clone_url: "",
-                               install_script: "",
-                               release_name: "",
-                               service_name: "",
-                               docker_repository: "",
-                               helm_repository: {name: "", repo_url: ""},
-                               helm_chart: "",
-                               helm_chart_container_name: "",
-                               rolling_update_tag: "",
-                               container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
-                               white_list_container_names: [""]} )
+                                        source_cnf_file: "",
+                                        source_cnf_dir: "",
+                                        yml_file_path: "",
+                                        install_method: {:helm_chart, ""},
+                                        manifest_directory: "",
+                                        helm_directory: "", 
+                                        helm_chart_path: "", 
+                                        manifest_file_path: "",
+                                        git_clone_url: "",
+                                        install_script: "",
+                                        release_name: "",
+                                        service_name: "",
+                                        docker_repository: "",
+                                        helm_repository: {name: "", repo_url: ""},
+                                        helm_chart: "",
+                                        helm_chart_container_name: "",
+                                        rolling_update_tag: "",
+                                        container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
+                                        white_list_container_names: [""]} )
     end
     yield args, config
   rescue ex

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -31,7 +31,7 @@ EmbeddedFileManager.cri_tools
 EmbeddedFileManager.reboot_daemon
 
 def task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
-  # LOGGING.info("single_or_all_cnfs_task_runner: #{args.inspect}")
+  LOGGING.info("task_runner args: #{args.inspect}")
   if check_cnf_config(args)
     single_task_runner(args, &block)
   else
@@ -56,7 +56,7 @@ end
 
 # TODO give example for calling
 def single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
-  LOGGING.debug("task_runner args: #{args.inspect}")
+  LOGGING.debug("single_task_runner args: #{args.inspect}")
   begin
     if args.named["cnf-config"]? # platform tests don't have a cnf-config
       config = CNFManager::Config.parse_config_yml(args.named["cnf-config"].as(String))    
@@ -271,25 +271,29 @@ def check_cnf_config(args)
   cnf
 end
 
-def check_all_cnf_args(args)
-  VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
-  cnf = check_cnf_config(args)
-  deploy_with_chart = true
-  if cnf 
-    VERBOSE_LOGGING.info "all cnf: #{cnf}" if check_verbose(args)
-    if args.named["deploy_with_chart"]? && args.named["deploy_with_chart"] == "false"
-      deploy_with_chart = false
-    end
-	end
-  return cnf, deploy_with_chart
-end
-
-def check_cnf_config_then_deploy(args)
-  config_file, deploy_with_chart = check_all_cnf_args(args)
-  cli_hash = CNFManager.sample_setup_cli_args(args)
-  # CNFManager.sample_setup_args(sample_dir: config_file, deploy_with_chart: deploy_with_chart, args: args, verbose: check_verbose(args) ) if config_file
-  CNFManager.sample_setup(cli_hash) if config_file
-end
+# def check_all_cnf_args(args)
+#   VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
+#   cnf = check_cnf_config(args)
+#   deploy_with_chart = true
+#   if cnf 
+#     VERBOSE_LOGGING.info "all cnf: #{cnf}" if check_verbose(args)
+#     if args.named["deploy_with_chart"]? && args.named["deploy_with_chart"] == "false"
+#       deploy_with_chart = false
+#     end
+# 	end
+#   return cnf, deploy_with_chart
+# end
+#
+# def check_cnf_config_then_deploy(args)
+#   LOGGING.info "check_cnf_config_then_deploy args: #{args.inspect}"
+#   config_file, deploy_with_chart = check_all_cnf_args(args)
+#   if config_file
+#     cli_hash = CNFManager.sample_setup_cli_args(args)
+#     CNFManager.sample_setup(cli_hash) if config_file
+#   else 
+#     LOGGING.error "not deploying in check_cnf_config_then_deploy because there is not config_file"
+#   end
+# end
 
 def toggle(toggle_name)
   toggle_on = false


### PR DESCRIPTION
# [BUG] After running cnf_setup, cnf-conformance errors "you must provide cnf-config or cnf-path" when running tests after the setup. #572

## Description
(name of issue/change)

## Issues:
Refs: #572

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
