### PR TITLE
[Feature] Add the date or a date+time to the dev snapshots tag for auto sorting on GitHub release page #530

### DIFF
--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -192,7 +192,7 @@ TEMPLATE
       {% puts "current_branch during compile: #{current_branch}" %}
       {% puts "current_tag during compile: #{current_tag}" %}
       {% if current_tag.strip == "" %}
-        VERSION = {{current_branch}} + "-{{current_hash.strip}}"
+        VERSION = {{current_branch}} + "-#{Time.local.to_s("%Y-%m-%d-%H%M%S")}-{{current_hash.strip}}"
       {% else %}
         VERSION = {{current_tag.strip}}
       {% end %}


### PR DESCRIPTION
# [Feature] Add the date or a date+time to the dev snapshots tag for auto sorting on GitHub release page #530

## Description
[Feature] Add the date or a date+time to the dev snapshots tag for auto sorting on GitHub release page #530

## Issues:
Refs: ##530

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
