### PR TITLE
[Feature] cnf_manager references to kubectl get should be moved to KubectlClient Module

### DIFF
--- a/src/cnf-conformance.cr
+++ b/src/cnf-conformance.cr
@@ -9,7 +9,6 @@ desc "The CNF Conformance program enables interoperability of CNFs from multiple
 task "all", ["workload", "platform"] do  |_, args|
   VERBOSE_LOGGING.info "all" if check_verbose(args)
 
-  # TODO make a workload and a platform total points
   total = total_points
   if total > 0
     stdout_success "Final score: #{total} of #{total_max_points}"

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -4,117 +4,9 @@ require "colorize"
 require "totem"
 require "./utils/utils.cr"
 
-# desc "Sets up sample CoreDNS CNF"
-# task "sample_coredns_setup", ["helm_local_install"] do |_, args|
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-#       # response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# task "sample_coredns_with_wait_setup", ["helm_local_install"] do |_, args|
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf", args: args, verbose: true)
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml", "verbose"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# desc "Sets up sample CoreDNS CNF with source"
-# task "sample_coredns_source_setup", ["helm_local_install"] do |_, args|
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-coredns-cnf-source", args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml", "verbose", "wait_count=0"])
-#    response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf-source/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# desc "Sets up an alternate sample CoreDNS CNF"
-# task "sample_coredns", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "sample_coredns new setup" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# desc "Sets up a Bad helm CNF Setup"
-# task "bad_helm_cnf_setup", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "bad_helm_cnf_setup" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-bad_helm_coredns-cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# task "sample_privileged_cnf_whitelisted_setup", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "sample_privileged_cnf_whitelisted_setup" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_whitelisted_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# task "sample_privileged_cnf_non_whitelisted_setup", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "sample_privileged_cnf_non_whitelisted_setup" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_privileged_cnf", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# task "sample_coredns_bad_liveness", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "sample_coredns_bad_liveness" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample_coredns_bad_liveness", deploy_with_chart: false, args: args, verbose: true, wait_count: 0 )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
-# task "sample_generic_cnf_setup", ["helm_local_install"] do |_, args|
-#   VERBOSE_LOGGING.info "sample_generic_cnf" if check_verbose(args)
-#   # CNFManager.sample_setup_args(sample_dir: "sample-cnfs/sample-generic-cnf", deploy_with_chart: false, args: args, verbose: true )
-#   args = Sam::Args.new(["cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml", "verbose", "wait_count=0"])
-#   response_s = `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-generic-cnf/cnf-conformance.yml verbose wait_count=0`
-#   cli_hash = CNFManager.sample_setup_cli_args(args)
-#   CNFManager.sample_setup(cli_hash)
-# end
-
 task "cnf_setup", ["helm_local_install"] do |_, args|
   VERBOSE_LOGGING.info "cnf_setup" if check_verbose(args)
   VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
-  # if args.named.keys.includes? "cnf-config"
-  #   yml_file = args.named["cnf-config"].as(String)
-  #   # example_cnf = File.dirname(File.expand_path(yml_file))
-  #   cnf = File.dirname(yml_file)
-  # elsif args.named.keys.includes? "cnf-path"
-  #   cnf = args.named["cnf-path"].as(String)
-  # else
-  #   stdout_failure "Error: You must supply either cnf-config or cnf-path"
-  #   exit 1
-	# end
-  # if args.named.keys.includes? "wait_count"
-  #   wait_count = args.named["wait_count"].to_i
-  # elsif args.named.keys.includes? "wait-count"
-  #   wait_count = args.named["wait-count"].to_i
-  # else
-  #   wait_count = 180
-  # end
-  # VERBOSE_LOGGING.info "cnf_setup cnf: #{cnf}" if check_verbose(args)
-  # #TODO get cnf-conformance yml and if helm_directory supplied (or deploy with chart supplied) use deploy with chart
-  # if args.named["deploy_with_chart"]? && args.named["deploy_with_chart"] == "false"
-  #   deploy_with_chart = false
-  # else
-  #   deploy_with_chart = true
-  # end
-  # #TODO call sample_setup_cli_args
-  # CNFManager.sample_setup_args(sample_dir: cnf, deploy_with_chart: deploy_with_chart, args: args, verbose: check_verbose(args), wait_count: wait_count )
   cli_hash = CNFManager.sample_setup_cli_args(args)
   CNFManager.sample_setup(cli_hash)
 end
@@ -151,6 +43,7 @@ task "CNFManager.helm_repo_add" do |_, args|
 
 end
 
+#TODO force all cleanups to use generic cleanup
 task "sample_coredns_cleanup" do |_, args|
   CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-coredns-cnf", verbose: true)
 end

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -1,4 +1,23 @@
 require "./utils/system_information/helm.cr"
+require "./utils/embedded_file_manager.cr"
+
+CNF_DIR = "cnfs"
+CONFIG_FILE = "cnf-conformance.yml"
+TOOLS_DIR = "tools"
+BASE_CONFIG = "./config.yml"
+POINTSFILE = "points.yml"
+PASSED = "passed"
+FAILED = "failed"
+DEFAULT_POINTSFILENAME = "points_v1.yml"
+PRIVILEGED_WHITELIST_CONTAINERS = ["chaos-daemon"]
+
+#Embedded global text variables
+EmbeddedFileManager.node_failure_values
+EmbeddedFileManager.cri_tools
+EmbeddedFileManager.reboot_daemon
+EmbeddedFileManager.chaos_network_loss
+EmbeddedFileManager.chaos_cpu_hog
+EmbeddedFileManager.chaos_container_kill
 
 CNFSingleton = CNFGlobals.new
 class CNFGlobals

--- a/src/tasks/helmenv_setup.cr
+++ b/src/tasks/helmenv_setup.cr
@@ -30,7 +30,7 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
         # stable_repo = ""
         VERBOSE_LOGGING.debug stable_repo if check_verbose(args)
 
-        #TODO grep for version.BuildInfo{Version:"v3.1.1", GitCommit:"afe70585407b420d0097d07b21c47dc511525ac8", GitTreeState:"clean", GoVersion:"go1.13.8"} 
+        #TODO grep for specific version e.g. version.BuildInfo{Version:"v3.1.1", GitCommit:"afe70585407b420d0097d07b21c47dc511525ac8", GitTreeState:"clean", GoVersion:"go1.13.8"} 
       ensure
         cd = `cd #{current_dir}`
         VERBOSE_LOGGING.debug cd if check_verbose(args)

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -30,7 +30,7 @@ namespace "platform" do
         sha_list = named_sha_list(state_metric_releases)
         LOGGING.debug "sha_list: #{sha_list}"
 
-        # TODO find hash for image
+        # find hash for image
         imageids = KubectlClient::Get.all_container_repo_digests
         LOGGING.debug "imageids: #{imageids}"
         found = false
@@ -169,7 +169,7 @@ end
         sha_list = named_sha_list(prometheus_adapter_releases)
         LOGGING.debug "sha_list: #{sha_list}"
 
-        # TODO find hash for image
+        # find hash for image
         imageids = KubectlClient::Get.all_container_repo_digests
         LOGGING.debug "imageids: #{imageids}"
         found = false
@@ -304,7 +304,7 @@ def named_sha_list(resp_json)
     end
   else
     parsed_json["results"].not_nil!.as_a.reduce([] of Hash(String, String)) do |acc, i|
-      #TODO always use amd64
+      # always use amd64
       amd64image = i["images"].as_a.find{|x| x["architecture"].as_s == "amd64"}
       LOGGING.debug "amd64image: #{amd64image}"
       if amd64image && amd64image["digest"]?

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -2,11 +2,9 @@
 desc "Platform Tests"
 task "platform", ["helm_local_install", "k8s_conformance", "platform:observability", "platform:resilience", "platform:hardware_and_scheduling"]  do |_, args|
   VERBOSE_LOGGING.info "platform" if check_verbose(args)
-  #TODO add CRYSTAL_ENV=TEST in new ISSUES when testing ./cnf-conformance platform or ./cnf-conformance all
 
   total = total_points("platform")
   if total > 0
-    #TODO make new platform_total_points and platform_total_max_points
     stdout_success "Final platform score: #{total} of #{total_max_points("platform")}"
   else
     stdout_failure "Final platform score: #{total} of #{total_max_points("platform")}"
@@ -23,8 +21,6 @@ desc "Does the platform pass the K8s conformance tests?"
 task "k8s_conformance" do |_, args|
   VERBOSE_LOGGING.info "k8s_conformance" if check_verbose(args)
   begin
-    #TODO enable full test with production mode
-    #sonobuoy = `sonobuoy run --wait` if PRODUCTION_MODE and not in test_mode
     current_dir = FileUtils.pwd 
     VERBOSE_LOGGING.debug current_dir if check_verbose(args)
     sonobuoy = "#{current_dir}/#{TOOLS_DIR}/sonobuoy/sonobuoy"
@@ -34,7 +30,6 @@ task "k8s_conformance" do |_, args|
     VERBOSE_LOGGING.info delete if check_verbose(args)
 
     # Run the tests
-    #TODO when in test mode --mode quick, prod mode no quick
     testrun = ""
     VERBOSE_LOGGING.info ENV["CRYSTAL_ENV"]? if check_verbose(args)
     if ENV["CRYSTAL_ENV"]? == "TEST"

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -1,6 +1,5 @@
 require "totem"
 require "colorize"
-require "./cnf_manager.cr"
 require "logger"
 require "halite"
 

--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -1,6 +1,5 @@
 require "totem"
 require "colorize"
-require "./cnf_manager.cr"
 require "halite"
 
 module Helm

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -8,30 +8,7 @@ require "file_utils"
 require "option_parser"
 require "../constants.cr"
 
-# TODO make constants local or always retrieve from environment variables
-# TODO Move constants out
 # TODO put these functions into a module
-
-# TODO: error with proper exit_code when any of these don't exist and ask user to run setup command
-CNF_DIR = "cnfs"
-CONFIG_FILE = "cnf-conformance.yml"
-TOOLS_DIR = "tools"
-BASE_CONFIG = "./config.yml"
-# Results.file = "cnf-conformance-results-#{Time.utc.to_s("%Y%m%d")}.log"
-# Results.file = "results.yml"
-POINTSFILE = "points.yml"
-PASSED = "passed"
-FAILED = "failed"
-DEFAULT_POINTSFILENAME = "points_v1.yml"
-PRIVILEGED_WHITELIST_CONTAINERS = ["chaos-daemon"]
-
-#Embedded global text variables
-EmbeddedFileManager.node_failure_values
-EmbeddedFileManager.cri_tools
-EmbeddedFileManager.reboot_daemon
-EmbeddedFileManager.chaos_network_loss
-EmbeddedFileManager.chaos_cpu_hog
-EmbeddedFileManager.chaos_container_kill
 
 def task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
   LOGGING.info("task_runner args: #{args.inspect}")
@@ -664,5 +641,3 @@ def optional_key_as_string(totem_config, key_name)
   "#{totem_config[key_name]? && totem_config[key_name].as_s?}"
 end
 
-# TODO move to kubectl_client
-# TODO make resource version

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -193,6 +193,7 @@ end
 LOGGING = LogginGenerator.new
 VERBOSE_LOGGING = VerboseLogginGenerator.new
 
+#TODO no longer used, removed
 def generate_version
   version = ""
   if ReleaseManager.on_a_tag?
@@ -250,30 +251,6 @@ def check_cnf_config(args)
   LOGGING.info("check_cnf_config cnf: #{cnf}")
   cnf
 end
-
-# def check_all_cnf_args(args)
-#   VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
-#   cnf = check_cnf_config(args)
-#   deploy_with_chart = true
-#   if cnf 
-#     VERBOSE_LOGGING.info "all cnf: #{cnf}" if check_verbose(args)
-#     if args.named["deploy_with_chart"]? && args.named["deploy_with_chart"] == "false"
-#       deploy_with_chart = false
-#     end
-# 	end
-#   return cnf, deploy_with_chart
-# end
-#
-# def check_cnf_config_then_deploy(args)
-#   LOGGING.info "check_cnf_config_then_deploy args: #{args.inspect}"
-#   config_file, deploy_with_chart = check_all_cnf_args(args)
-#   if config_file
-#     cli_hash = CNFManager.sample_setup_cli_args(args)
-#     CNFManager.sample_setup(cli_hash) if config_file
-#   else 
-#     LOGGING.error "not deploying in check_cnf_config_then_deploy because there is not config_file"
-#   end
-# end
 
 def toggle(toggle_name)
   toggle_on = false
@@ -511,19 +488,6 @@ def failed_required_tasks
     end
   end
 end
-
-# def total_points
-#   yaml = File.open("#{Results.file}") do |file|
-#     YAML.parse(file)
-#   end
-#   yaml["items"].as_a.reduce(0) do |acc, i|
-#     if i["points"].as_i?
-#       (acc + i["points"].as_i)
-#     else
-#       acc
-#     end
-#   end
-# end
 
 def total_points(tag=nil)
   if tag

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -44,6 +44,7 @@ task "ip_addresses" do |_, args|
       resp
     else
       # TODO If no helm chart directory, exit with 0 points
+      # ADD SKIPPED tag for points.yml to allow for 0 points
       Dir.cd(cdir)
       resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")
     end
@@ -339,8 +340,6 @@ task "secrets_used" do |_, args|
       LOGGING.info "resource: #{resource}"
       LOGGING.info "volumes: #{volumes}"
 
-      # TODO cnf must have either a used secret volume or a defined container secret key ref
-      # test_passed = true 
       volume_test_passed = false
       secret_volume_exists = false
       secret_volume_mounted = true 
@@ -374,11 +373,11 @@ task "secrets_used" do |_, args|
 
       
       # TODO if a container exists which has a secretkeyref defined 
-      #   and also has a corresponding k8s secret defined, the whole test passes
+      # and also has a corresponding k8s secret defined, the whole test passes.
 
-      # TODO if there are any containers that have a secretkeyref defined 
+      #  if there are any containers that have a secretkeyref defined 
       #  but do not have a corresponding k8s secret defined, this 
-      #  is an installation problem
+      #  is an installation problem, and does not stop the test from passing
 
       secrets = KubectlClient::Get.secrets
       secret_keyref_found = false 
@@ -398,8 +397,8 @@ task "secrets_used" do |_, args|
       # if at least 1 secret volume exists, but it is not mounted, test fails
       # if no secret volumes exist, but a container secret exists 
       #  and is defined, test passes
-      # if at least 1 container secret exists, but it is not defined, (see 
-      #  TODO on line 374)
+      # if at least 1 container secret exists, but it is not defined, this 
+      # is an installation problem
       # if no secret volume exists and no container secret exists, test fails
       test_passed = false
       if secret_keyref_found || volume_test_passed

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -35,7 +35,7 @@ task "chaos_network_loss", ["install_chaosmesh"] do |_, args|
         VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_network_loss.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
-        if wait_for_test("NetworkChaos", "network-loss")
+        if ChaosMeshSetup.wait_for_test("NetworkChaos", "network-loss")
           LOGGING.info( "Wait Done")
           unless KubectlClient::Get.resource_desired_is_available?(resource["kind"].as_s, resource["name"].as_s)
             test_passed = false
@@ -43,6 +43,7 @@ task "chaos_network_loss", ["install_chaosmesh"] do |_, args|
           end
         else
           # TODO Change this to an exception (points = 0)
+          # Add SKIPPED to points.yml and set to points = 0
           # e.g. upsert_exception_task
           test_passed = false
           puts "Chaosmesh failed to finish for resource: #{resource["name"]}".colorize(:red)
@@ -81,13 +82,14 @@ task "chaos_cpu_hog", ["install_chaosmesh"] do |_, args|
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_cpu_hog.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
         # TODO fail if exceeds
-        if wait_for_test("StressChaos", "burn-cpu")
+        if ChaosMeshSetup.wait_for_test("StressChaos", "burn-cpu")
           unless KubectlClient::Get.resource_desired_is_available?(resource["kind"].as_s, resource["name"].as_s)
             test_passed = false
             puts "Chaosmesh Application pod is not healthy after high CPU consumption for resource: #{resource["name"]}".colorize(:red)
           end
         else
           # TODO Change this to an exception (points = 0)
+          # TODO Add SKIPPED to points.yml and set to points = 0
           # e.g. upsert_exception_task
             test_passed = false
             puts "Chaosmesh failed to finish for resource: #{resource["name"]}".colorize(:red)
@@ -130,19 +132,16 @@ task "chaos_container_kill", ["install_chaosmesh"] do |_, args|
         VERBOSE_LOGGING.debug "#{chaos_config}" if check_verbose(args)
         run_chaos = `kubectl create -f "#{destination_cnf_dir}/chaos_container_kill.yml"`
         VERBOSE_LOGGING.debug "#{run_chaos}" if check_verbose(args)
-        if wait_for_test("PodChaos", "container-kill")
-          # KubectlClient::Get.wait_for_install(resource["name"], wait_count=60)
+        if ChaosMeshSetup.wait_for_test("PodChaos", "container-kill")
           KubectlClient::Get.resource_wait_for_install(resource["kind"].as_s, resource["name"].as_s, wait_count=60)
         else
           # TODO Change this to an exception (points = 0)
+          # TODO Add SKIPPED to points.yml and set to points = 0
           # e.g. upsert_exception_task
           test_passed = false
           puts "Chaosmesh chaos_container_kill failed to finish forresource: #{resource} and container: #{container.as_h["name"].as_s}".colorize(:red)
         end
       end
-      # TODO fail if exceeds
-      # if wait_for_test("PodChaos", "container-kill")
-      # KubectlClient::Get.wait_for_install(deployment_name, wait_count=60)
 
       resource_names << {"kind" => resource["kind"].as_s,
                          "name" => resource["name"].as_s}

--- a/src/tasks/workload/scalability.cr
+++ b/src/tasks/workload/scalability.cr
@@ -89,6 +89,7 @@ def change_capacity(base_replicas, target_replica_count, args, config, resource 
   initialization_time = base_replicas.to_i * 10
   VERBOSE_LOGGING.info "resource: #{resource["metadata"]["name"]}" if check_verbose(args)
 
+  #TODO make a KubectlClient.scale command
   case resource["kind"].as_s.downcase
   when "deployment"
     LOGGING.debug "kubectl scale #{resource["kind"]}.v1.apps/#{resource["metadata"]["name"]} --replicas=#{base_replicas}"

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -11,9 +11,6 @@ end
 
 desc "Check if any containers are running in privileged mode"
 task "privileged" do |_, args|
-  #TODO Document all arguments
-  #TODO check if container exists
-  #TODO Check if args exist
   task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "privileged" if check_verbose(args)
     white_list_container_names = config.cnf_config[:white_list_container_names]

--- a/src/tasks/workload/statelessness.cr
+++ b/src/tasks/workload/statelessness.cr
@@ -22,7 +22,7 @@ task "volume_hostpath_not_found" do |_, args|
     task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
       hostPath_found = nil 
       begin
-        # TODO check to see if this fails with container storage (and then erroneously fails the test as having hostpath volumes)
+        # TODO check to see if volume is actually mounted.  Check to see if mount (without volume) has host path as well
         volumes = resource.dig?("spec", "template", "spec", "volumes")
         if volumes
           hostPath_not_found = volumes.as_a.none? do |volume| 


### PR DESCRIPTION
# [Feature] cnf_manager references to kubectl get should be moved to KubectlClient Module #590

## Description
[Feature] cnf_manager references to kubectl get should be moved to KubectlClient Module #590

## Issues:
Refs: #590

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
