### PR TITLE
[PATCH] Fix for 'converting YAML to JSON error' during cnf_setup for immutable_configmap

### DIFF
--- a/sample-cnfs/sample_immutable_configmap_some/chart/templates/configmap-test-not-immutable.yaml
+++ b/sample-cnfs/sample_immutable_configmap_some/chart/templates/configmap-test-not-immutable.yaml
@@ -1,6 +1,7 @@
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: myapp
-  data:
-    api.server: https://example.com
+---             
+apiVersion: v1   
+data:      
+  api.server: "https://example.com"
+kind: ConfigMap
+metadata:                                                                                                                                                               
+  name: myapp


### PR DESCRIPTION
## Description
Patch suggestion for yaml parsing error on `sample-cnfs/sample_immutable_configmap_some/chart/templates/configmap-test-not-immutable.yaml` that was erroring during `cnf_setup` 

## Issues:
Refs: #508

https://github.com/cncf/cnf-conformance/issues/508#issuecomment-778501963

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [x] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
