### PR TITLE
#619 registry port now uses the full k8s container image. 

### DIFF
--- a/sample-cnfs/sample_local_registry_org_image/README.md
+++ b/sample-cnfs/sample_local_registry_org_image/README.md
@@ -1,0 +1,39 @@
+# Set up Sample CoreDNS CNF
+./sample-cnfs/sample-coredns-cnf/readme.md
+# Prerequistes
+### Install helm
+```
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+```
+### Optional: Use a helm version manager
+https://github.com/yuya-takeyama/helmenv
+Check out helmenv into any path (here is ${HOME}/.helmenv)
+```
+${HOME}/.helmenv)
+$ git clone https://github.com/yuya-takeyama/helmenv.git ~/.helmenv
+```
+Add ~/.helmenv/bin to your $PATH any way you like
+```
+$ echo 'export PATH="$HOME/.helmenv/bin:$PATH"' >> ~/.bash_profile
+```
+```
+helmenv versions 
+helmenv install <version 3.1?>
+```
+
+### core-dns installation
+```
+helm install coredns stable/coredns
+```
+### Pull down the helm chart code, untar it, and put it in the cnfs/coredns directory
+```
+helm pull stable/coredns
+```
+### Example cnf-conformance config file for sample-core-dns-cnf
+In ./cnfs/sample-core-dns-cnf/cnf-conformance.yml
+```
+---
+container_names: [coredns-coredns] 
+```

--- a/sample-cnfs/sample_local_registry_org_image/chart/.helmignore
+++ b/sample-cnfs/sample_local_registry_org_image/chart/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/sample-cnfs/sample_local_registry_org_image/chart/Chart.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+appVersion: 1.6.7
+description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS
+  Services
+home: https://coredns.io
+icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
+keywords:
+- coredns
+- dns
+- kubedns
+maintainers:
+- email: hello@acale.ph
+  name: Acaleph
+- email: shashidhara.huawei@gmail.com
+  name: shashidharatd
+- email: andor44@gmail.com
+  name: andor44
+- email: manuel@rueg.eu
+  name: mrueg
+name: coredns
+sources:
+- https://github.com/coredns/coredns
+version: 1.10.0

--- a/sample-cnfs/sample_local_registry_org_image/chart/README.md
+++ b/sample-cnfs/sample_local_registry_org_image/chart/README.md
@@ -1,0 +1,138 @@
+# CoreDNS
+
+[CoreDNS](https://coredns.io/) is a DNS server that chains plugins and provides DNS Services
+
+# TL;DR;
+
+```console
+$ helm install --name coredns --namespace=kube-system stable/coredns
+```
+
+## Introduction
+
+This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. This chart will provide DNS Services and can be deployed in multiple configuration to support various scenarios listed below:
+
+ - CoreDNS as a cluster dns service and a drop-in replacement for Kube/SkyDNS. This is the default mode and CoreDNS is deployed as cluster-service in kube-system namespace. This mode is chosen by setting `isClusterService` to true.
+ - CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
+ - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd plugin for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed.
+
+## Prerequisites
+
+-	Kubernetes 1.10 or later
+
+## Installing the Chart
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name coredns --namespace=kube-system stable/coredns
+```
+
+The command deploys CoreDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists various ways to override default configuration during deployment.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete coredns
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+| Parameter                               | Description                                                                           | Default                                                     |
+|:----------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------|
+| `image.repository`                      | The image repository to pull from                                                     | coredns/coredns                                             |
+| `image.tag`                             | The image tag to pull from                                                            | `v1.6.7`                                                    |
+| `image.pullPolicy`                      | Image pull policy                                                                     | IfNotPresent                                                |
+| `replicaCount`                          | Number of replicas                                                                    | 1                                                           |
+| `resources.limits.cpu`                  | Container maximum CPU                                                                 | `100m`                                                      |
+| `resources.limits.memory`               | Container maximum memory                                                              | `128Mi`                                                     |
+| `resources.requests.cpu`                | Container requested CPU                                                               | `100m`                                                      |
+| `resources.requests.memory`             | Container requested memory                                                            | `128Mi`                                                     |
+| `serviceType`                           | Kubernetes Service type                                                               | `ClusterIP`                                                 |
+| `prometheus.monitor.enabled`            | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                                     |
+| `prometheus.monitor.additionalLabels`   | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {}                                                          |
+| `prometheus.monitor.namespace`          | Selector to select which namespaces the Endpoints objects are discovered from.        | `""`                                                        |
+| `service.clusterIP`                     | IP address to assign to service                                                       | `""`                                                        |
+| `service.loadBalancerIP`                | IP address to assign to load balancer (if supported)                                  | `""`                                                        |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                  | `[]`                                                        |
+| `service.annotations`                   | Annotations to add to service                                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9153"}`|
+| `serviceAccount.create`                 | If true, create & use serviceAccount                                                  | false                                                       |
+| `serviceAccount.name`                   | If not set & create is true, use template fullname                                    |                                                             |
+| `rbac.create`                           | If true, create & use RBAC resources                                                  | true                                                        |
+| `rbac.pspEnable`                        | Specifies whether a PodSecurityPolicy should be created.                              | `false`                                                     |
+| `isClusterService`                      | Specifies whether chart should be deployed as cluster-service or normal k8s app.      | true                                                        |
+| `priorityClassName`                     | Name of Priority Class to assign pods                                                 | `""`                                                        |
+| `servers`                               | Configuration for CoreDNS and plugins                                                 | See values.yml                                              |
+| `affinity`                              | Affinity settings for pod assignment                                                  | {}                                                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                        | {}                                                          |
+| `tolerations`                           | Tolerations for pod assignment                                                        | []                                                          |
+| `zoneFiles`                             | Configure custom Zone files                                                           | []                                                          |
+| `extraSecrets`                          | Optional array of secrets to mount inside the CoreDNS container                       | []                                                          |
+| `customLabels`                          | Optional labels for Deployment(s), Pod, Service, ServiceMonitor objects               | {}                                                          |
+| `podDisruptionBudget`                   | Optional PodDisruptionBudget                                                          | {}                                                          |
+| `autoscaler.enabled`                    | Optionally enabled a cluster-proportional-autoscaler for CoreDNS                      | `false`                                                     |
+| `autoscaler.coresPerReplica`            | Number of cores in the cluster per CoreDNS replica                                    | `256`                                                       |
+| `autoscaler.nodesPerReplica`            | Number of nodes in the cluster per CoreDNS replica                                    | `16`                                                        |
+| `autoscaler.image.repository`           | The image repository to pull autoscaler from                                          | k8s.gcr.io/cluster-proportional-autoscaler-amd64            |
+| `autoscaler.image.tag`                  | The image tag to pull autoscaler from                                                 | `1.7.1`                                                     |
+| `autoscaler.image.pullPolicy`           | Image pull policy for the autoscaler                                                  | IfNotPresent                                                |
+| `autoscaler.priorityClassName`          | Optional priority class for the autoscaler pod. `priorityClassName` used if not set.  | `""`                                                        |
+| `autoscaler.affinity`                   | Affinity settings for pod assignment for autoscaler                                   | {}                                                          |
+| `autoscaler.nodeSelector`               | Node labels for pod assignment for autoscaler                                         | {}                                                          |
+| `autoscaler.tolerations`                | Tolerations for pod assignment for autoscaler                                         | []                                                          |
+| `autoscaler.resources.limits.cpu`       | Container maximum CPU for cluster-proportional-autoscaler                             | `20m`                                                       |
+| `autoscaler.resources.limits.memory`    | Container maximum memory for cluster-proportional-autoscaler                          | `10Mi`                                                      |
+| `autoscaler.resources.requests.cpu`     | Container requested CPU for cluster-proportional-autoscaler                           | `20m`                                                       |
+| `autoscaler.resources.requests.memory`  | Container requested memory for cluster-proportional-autoscaler                        | `10Mi`                                                      |
+| `autoscaler.configmap.annotations`      | Annotations to add to autoscaler config map. For example to stop CI renaming them     | {}                                                          |
+
+See `values.yaml` for configuration notes. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name coredns \
+  --set rbac.create=false \
+    stable/coredns
+```
+
+The above command disables automatic creation of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name coredns -f values.yaml stable/coredns
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+
+## Caveats
+
+The chart will automatically determine which protocols to listen on based on
+the protocols you define in your zones. This means that you could potentially
+use both "TCP" and "UDP" on a single port.
+Some cloud environments like "GCE" or "Azure container service" cannot
+create external loadbalancers with both "TCP" and "UDP" protocols. So
+When deploying CoreDNS with `serviceType="LoadBalancer"` on such cloud
+environments, make sure you do not attempt to use both protocols at the same
+time.
+
+## Autoscaling
+
+By setting `autoscaler.enabled = true` a
+[cluster-proportional-autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler)
+will be deployed. This will default to a coredns replica for every 256 cores, or
+16 nodes in the cluster. These can be changed with `autoscaler.coresPerReplica`
+and `autoscaler.nodesPerReplica`. When cluster is using large nodes (with more
+cores), `coresPerReplica` should dominate. If using small nodes,
+`nodesPerReplica` should dominate.
+
+This also creates a ServiceAccount, ClusterRole, and ClusterRoleBinding for
+the autoscaler deployment.
+
+`replicaCount` is ignored if this is enabled.

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/NOTES.txt
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/NOTES.txt
@@ -1,0 +1,30 @@
+{{- if .Values.isClusterService }}
+CoreDNS is now running in the cluster as a cluster-service.
+{{- else }}
+CoreDNS is now running in the cluster.
+It can be accessed using the below endpoint
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "coredns.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get svc -w {{ template "coredns.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "coredns.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo $SERVICE_IP
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+    "{{ template "coredns.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    from within the cluster
+{{- end }}
+{{- end }}
+
+It can be tested with the following:
+
+1. Launch a Pod with DNS tools:
+
+kubectl run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools
+
+2. Query the DNS server:
+
+/ # host kubernetes

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/_helpers.tpl
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/_helpers.tpl
@@ -1,0 +1,149 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "coredns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "coredns.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.servicePorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{/* Optionally enable tcp for this service as well */}}
+                {{- if eq .use_tcp true }}
+                    {{- $innerdict := set $innerdict "istcp" true -}}
+                {{- end }}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- $innerdict := set $innerdict "istcp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.containerPorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{/* Optionally enable tcp for this service as well */}}
+                {{- if eq .use_tcp true }}
+                    {{- $innerdict := set $innerdict "istcp" true -}}
+                {{- end }}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- $innerdict := set $innerdict "istcp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {containerPort: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {containerPort: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "coredns.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "coredns.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrole-autoscaler.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrole-autoscaler.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list","watch"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrole.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+{{- if .Values.rbac.pspEnable }}
+- apiGroups:
+  - policy
+  - extensions
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "coredns.fullname" . }}
+{{- end }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrolebinding-autoscaler.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrolebinding-autoscaler.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "coredns.fullname" . }}-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrolebinding.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "coredns.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "coredns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/configmap-autoscaler.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/configmap-autoscaler.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaler.enabled }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+    {{- if .Values.customLabels }}
+    {{- toYaml .Values.customLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.autoscaler.configmap.annotations }}
+  annotations:
+    {{- toYaml .Values.autoscaler.configmap.annotations | nindent 4 }}
+  {{- end }}
+data:
+  # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+  # If using small nodes, "nodesPerReplica" should dominate.
+  linear: |-
+    {
+      "coresPerReplica": {{ .Values.autoscaler.coresPerReplica | float64 }},
+      "nodesPerReplica": {{ .Values.autoscaler.nodesPerReplica | float64 }},
+      "preventSinglePointFailure": true
+    }
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/configmap.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+data:
+  Corefile: |-
+    {{ range .Values.servers }}
+    {{- range $idx, $zone := .zones }}{{ if $idx }} {{ else }}{{ end }}{{ default "" $zone.scheme }}{{ default "." $zone.zone }}{{ else }}.{{ end -}}
+    {{- if .port }}:{{ .port }} {{ end -}}
+    {
+      {{- range .plugins }}
+        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
+{{ .configBlock | indent 12 }}
+        }{{ end }}
+      {{- end }}
+    }
+    {{ end }}
+  {{- range .Values.zoneFiles }}
+  {{ .filename }}: {{ toYaml .contents | indent 4 }}
+  {{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/deployment-autoscaler.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/deployment-autoscaler.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.autoscaler.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name }}-autoscaler
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  template:
+    metadata:
+      labels:
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name }}-autoscaler
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- if .Values.customLabels }}
+        {{ toYaml .Values.customLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap-autoscaler.yaml") . | sha256sum }}
+        {{- if .Values.isClusterService }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "coredns.fullname" . }}-autoscaler
+      {{- $priorityClassName := default .Values.priorityClassName .Values.autoscaler.priorityClassName }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.autoscaler.affinity }}
+      affinity:
+{{ toYaml .Values.autoscaler.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.autoscaler.tolerations }}
+      tolerations:
+{{ toYaml .Values.autoscaler.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.autoscaler.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.autoscaler.nodeSelector | indent 8 }}
+      {{- end }}
+      containers:
+      - name: autoscaler
+        image: "{{ .Values.autoscaler.image.repository }}:{{ .Values.autoscaler.image.tag }}"
+        imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.autoscaler.resources | indent 10 }}
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace={{ .Release.Namespace }}
+          - --configmap={{ template "coredns.fullname" . }}-autoscaler
+          - --target=Deployment/{{ template "coredns.fullname" . }}
+          - --logtostderr=true
+          - --v=2
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/deployment.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  {{- if not .Values.autoscaler.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 10%
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name | quote }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}
+  template:
+    metadata:
+      labels:
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name | quote }}
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 8 }}
+{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.isClusterService }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "coredns.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.isClusterService }}
+      dnsPolicy: Default
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      containers:
+      - name: "coredns"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+{{- range .Values.extraSecrets }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          readOnly: true
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+{{ include "coredns.containerPorts" . | indent 8 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "coredns.fullname" . }}
+            items:
+            - key: Corefile
+              path: Corefile
+            {{ range .Values.zoneFiles }}
+            - key: {{ .filename }}
+              path: {{ .filename }}
+            {{ end }}
+{{- range .Values.extraSecrets }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .name }}
+            defaultMode: 400
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/poddisruptionbudget.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name | quote }}
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/podsecuritypolicy.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/podsecuritypolicy.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.rbac.pspEnable }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    {{- end }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # Add back CAP_NET_BIND_SERVICE so that coredns can run on port 53
+  allowedCapabilities:
+  - CAP_NET_BIND_SERVICE
+    # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/service-metrics.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/service-metrics.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "coredns.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    app.kubernetes.io/component: metrics
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  ports:
+  - name: metrics
+    port: 9153
+    targetPort: 9153
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/service.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+{{ include "coredns.servicePorts" . | indent 2 -}}
+  type: {{ default "ClusterIP" .Values.serviceType }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/serviceaccount-autoscaler.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/serviceaccount-autoscaler.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/serviceaccount.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "coredns.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/templates/servicemonitor.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  {{- if .Values.prometheus.monitor.namespace }}
+  namespace: {{ .Values.prometheus.monitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    {{- if .Values.prometheus.monitor.additionalLabels }}
+{{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name | quote }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+{{- end }}

--- a/sample-cnfs/sample_local_registry_org_image/chart/values.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/values.yaml
@@ -1,0 +1,198 @@
+# Default values for coredns.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry:5000/coredns/coredns
+  tag: "1.6.7"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+serviceType: "ClusterIP"
+
+prometheus:
+  monitor:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+
+service:
+# clusterIP: ""
+# loadBalancerIP: ""
+# externalTrafficPolicy: ""
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9153"
+
+serviceAccount:
+  create: false
+  # The name of the ServiceAccount to use
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # If true, create & use RBAC resources
+  create: true
+  # If true, create and use PodSecurityPolicy
+  pspEnable: false
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # name:
+
+# isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
+isClusterService: true
+
+# Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
+priorityClassName: ""
+
+# Default zone is what Kubernetes recommends:
+# https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
+servers:
+- zones:
+  - zone: .
+  port: 53
+  plugins:
+  - name: errors
+  # Serves a /health endpoint on :8080, required for livenessProbe
+  - name: health
+    configBlock: |-
+      lameduck 5s
+  # Serves a /ready endpoint on :8181, required for readinessProbe
+  - name: ready
+  # Required to query kubernetes API for data
+  - name: kubernetes
+    parameters: cluster.local in-addr.arpa ip6.arpa
+    configBlock: |-
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+      ttl 30
+  # Serves a /metrics endpoint on :9153, required for serviceMonitor
+  - name: prometheus
+    parameters: 0.0.0.0:9153
+  - name: forward
+    parameters: . /etc/resolv.conf
+  - name: cache
+    parameters: 30
+  - name: loop
+  - name: reload
+  - name: loadbalance
+
+# Complete example with all the options:
+# - zones:                 # the `zones` block can be left out entirely, defaults to "."
+#   - zone: hello.world.   # optional, defaults to "."
+#     scheme: tls://       # optional, defaults to "" (which equals "dns://" in CoreDNS)
+#   - zone: foo.bar.
+#     scheme: dns://
+#     use_tcp: true        # set this parameter to optionally expose the port on tcp as well as udp for the DNS protocol
+#                          # Note that this will not work if you are also exposing tls or grpc on the same server
+#   port: 12345            # optional, defaults to "" (which equals 53 in CoreDNS)
+#   plugins:               # the plugins to use for this server block
+#   - name: kubernetes     # name of plugin, if used multiple times ensure that the plugin supports it!
+#     parameters: foo bar  # list of parameters after the plugin
+#     configBlock: |-      # if the plugin supports extra block style config, supply it here
+#       hello world
+#       foo bar
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# for example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
+
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+podDisruptionBudget: {}
+
+# configure custom zone files as per https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/
+zoneFiles: []
+#  - filename: example.db
+#    domain: example.com
+#    contents: |
+#      example.com.   IN SOA sns.dns.icann.com. noc.dns.icann.com. 2015082541 7200 3600 1209600 3600
+#      example.com.   IN NS  b.iana-servers.net.
+#      example.com.   IN NS  a.iana-servers.net.
+#      example.com.   IN A   192.168.99.102
+#      *.example.com. IN A   192.168.99.102
+
+# optional array of secrets to mount inside coredns container
+# possible usecase: need for secure connection with etcd backend
+extraSecrets: []
+# - name: etcd-client-certs
+#   mountPath: /etc/coredns/tls/etcd
+# - name: some-fancy-secret
+#   mountPath: /etc/wherever
+
+# Custom labels to apply to Deployment, Pod, Service, ServiceMonitor. Including autoscaler if enabled.
+customLabels: {}
+
+## Configue a cluster-proportional-autoscaler for coredns
+# See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
+autoscaler:
+  # Enabled the cluster-proportional-autoscaler
+  enabled: false
+
+  # Number of cores in the cluster per coredns replica
+  coresPerReplica: 256
+  # Number of nodes in the cluster per coredns replica
+  nodesPerReplica: 16
+
+  image:
+    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    tag: "1.7.1"
+    pullPolicy: IfNotPresent
+
+  # Optional priority class to be used for the autoscaler pods. priorityClassName used if not set.
+  priorityClassName: ""
+
+  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+  affinity: {}
+
+  # Node labels for pod assignment
+  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+
+  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+  tolerations: []
+
+  # resources for autoscaler pod
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "10Mi"
+    limits:
+      cpu: "20m"
+      memory: "10Mi"
+
+  # Options for autoscaler configmap
+  configmap:
+    ## Annotations for the coredns-autoscaler configmap
+    # i.e. strategy.spinnaker.io/versioned: "false" to ensure configmap isn't renamed
+    annotations: {}

--- a/sample-cnfs/sample_local_registry_org_image/cnf-conformance.yml
+++ b/sample-cnfs/sample_local_registry_org_image/cnf-conformance.yml
@@ -1,0 +1,17 @@
+---
+helm_directory: chart
+git_clone_url: 
+install_script: chart
+release_name: coredns
+deployment_name: coredns-coredns 
+deployment_label: k8s-app
+service_name: coredns-coredns
+application_deployment_names: [coredns]
+helm_chart_container_name: coredns
+container_names: 
+  - name: coredns 
+    rolling_update_test_tag: "1.8.0"
+    rolling_downgrade_test_tag: 1.6.7
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
+white_list_helm_chart_container_names: []

--- a/src/tasks/utils/docker_client.cr
+++ b/src/tasks/utils/docker_client.cr
@@ -4,7 +4,109 @@ require "./cnf_manager.cr"
 require "halite"
 
 module DockerClient
+  ##############################################
+  # All docker images can have one, two, three, or more segments. The docker images that have 
+  # multiple segments are separated by a slash.
+  #
+  # ** Multiple segments **
+  # (Fully qualified) registry name with optional port /Org/image combination
+  # Multiple segment examples: e.g. docker.io/coredns/coredns
+  # mydockerregistry.io:8080/coredns/coredns, mydockerregistry.io:8080/coredns/coredns:latest,	
+  # mydockerregistry.io:8080/privatecordnsorg/coredns/coredns:latest
+  #
+  # Two segment examples: coredns/coredns,
+  # 	docker.io/busybox,
+  # 	myhostname:5000/myimagename:mytag
+  #
+  #	1) If the first segment has a period . in it, then the segment is a 
+  # fully qualified domain name.
+  #
+  #	2) If the first segment has colon in it : everything after the colon 
+  # is a port number
+  #  a) If there are three or more segments, all segments (the middle 
+  # segments) from the first and before the last are org names
+  #
+  # 3) If the first segment is not a fully qualified domain name 
+  #  a) if there are two elements, the first element is an org
+  #  b) If there are three or more segments, all segments excluding 
+  #  the last are org names
+  #
+  # ** The last segment (or one segment) **
+  # Official docker image string
+  # e.g. busybox
+  #
+  # 4.a) If the docker image is only one segment,docker.io is used for the 
+  # registry, the whole segment is used image name, and if there is no 
+  # tag, `latest` is used as the tag 
+  #
+  # 4.b) Everything in the one segment (or the last segment if there are 
+  # multiple segments) is an image or image:tag combination.
+  # ```
+  # DockerClient.parse_image("mydockerregistry.io:8080/coredns/coredns:latest") 
+  # # => {"org_image" => "coredns/corends:latest", "org" => "coredns", 
+  # # "image" => "coredns:latest", "registry" => "mydockerregistry.io:8080", "tag" => "latest"}
+  # ```
+  def self.parse_image(fqdn_image_text)
+    resp = {"registry" => "", 
+            "org_image" => "",
+            "org" => "", 
+            "image_and_tag" => "", 
+            "image_name" => "", 
+            "tag" => ""}
+    size = fqdn_image_text.split("/").size 
+    first_segment = fqdn_image_text.split("/")[0]
+    last_segment = fqdn_image_text.split("/")[-1]
+
+    #	1) If the first segment has a period . in it, then the segment is a 
+    # fully qualified domain name.
+    #	2) If the first segment has colon in it : everything after the colon 
+    # is a port number
+    if (first_segment =~ /\./ || first_segment =~ /:/)
+      resp["registry"] = first_segment 
+      #  a) If there are three or more segments, all segments (the middle 
+      # segments) from the first and before the last are org names
+      if size > 2
+        resp["org"] = fqdn_image_text.split("/")[1..-2]
+      elsif size = 2
+        resp["org"] = first_segment
+      else
+        LOGGING.error "size of image text should never = 1 or nil: #{fqdn_image_text}"
+      end
+    else # first segment not a registry
+      resp["registry"] = ""
+      if size = 1
+        resp["org"] = ""
+        # 3) If the first segment is not a fully qualified domain name 
+        #  a) if there are two segments, the first segment is an org
+      elsif size = 2
+        resp["org"] = first_segment
+        #  b) If there are three or more segments, all segments (the middle 
+        # segments) after the first and before the last are org names
+      elsif size > 2
+        resp["org"] = fqdn_image_text.split("/")[0..-2]
+      end
+    end
+    resp["org_image"] = "#{resp["org"].empty? ? "" : resp["org"] + "/"}#{last_segment}"
+    # 4.a) If there is only one segment, docker.io is used for the 
+    # registry.  If there is no : in the image text, `latest` is used as the tag 
+    # 4.b) Everything in the one segment (or the last segment if there are 
+    # multiple segments) is an image or image:tag combination.
+    resp["image_and_tag"] = last_segment
+    if size == 1 
+        resp["registry"] = "docker.io"
+    end
+    resp["image_name"] = last_segment.image.split(":")[0]? 
+    if last_segment.image.split(":")[1]?
+        resp["tag"] = last_segment.image.split(":")[1]? 
+    else
+        resp["tag"] = "latest"
+    end
+    LOGGING.info "org/image:tag : #{resp}"
+    resp
+	end
+
   module Get
+    # TODO remove if not used
     def self.image_tags(image_name) : Halite::Response 
       LOGGING.info "tags image name: #{image_name}"
       # if image doesn't have a / in it, it has no user and is an official docker reposistory
@@ -16,7 +118,8 @@ module DockerClient
       end
       LOGGING.info "org/image:tag : #{image_name}"
       modified_image_with_repo = ((image_name =~ /\//) == nil) ? "library/" + image_name : image_name
- 
+
+      #TODO make this work with a local registry, if used in the future
       LOGGING.info "docker halite url: #{"https://hub.docker.com/v2/repositories/#{modified_image_with_repo}/tags/?page_size=100"}"
       docker_resp = Halite.get("https://hub.docker.com/v2/repositories/#{modified_image_with_repo}/tags/?page_size=100", headers: {"Authorization" => "JWT"})
       LOGGING.debug "docker image resp: #{docker_resp}"


### PR DESCRIPTION
#619 registry port now uses the full k8s container image. 

# CNF Conformance PR Template

## Description
#619 registry port now uses the full k8s container image. 

## Issues:
Refs: #619

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
