### PR TITLE
Bug/#614 cnf setup tests

### DIFF
--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -64,7 +64,9 @@ module Helm
     LOGGING.debug "workload_resource_by_kind ymls: #{ymls}"
     resources = ymls.select{|x| x["kind"]?==kind}.reject! {|x|
         # reject resources that contain the 'helm.sh/hook: test' annotation
-        x["metadata"]? && x["metadata"]["annotations"]? && x["metadata"]["annotations"]["helm.sh/hook"]? == "test"
+      LOGGING.debug "x[metadata]?: #{x["metadata"]?}"
+      LOGGING.debug "x[metadata][annotations]?: #{x["metadata"]? && x["metadata"]["annotations"]?}"
+      x.dig?("metadata","annotations","helm.sh/hook")
       }
     # end
     LOGGING.debug "resources: #{resources}"


### PR DESCRIPTION
# cnf setup now avoids helm tests and uses the dig command

## Description
cnf setup now avoids helm tests and uses the dig command

## Issues:
Refs: #614

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
