### PR TITLE
[BUG] rollback, rolling_version_change tests do not handle images that use a local registry with port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,4 @@ chaos_network_loss.yml
 chaos_cpu_hog.yml
 chaos_container_kill.yml
 /.idea/
-build.sh
-shards.sh
+*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tmp/
 chaos_network_loss.yml
 chaos_cpu_hog.yml
 chaos_container_kill.yml
+/.idea/
+build.sh
+shards.sh

--- a/sample-cnfs/sample_local_registry/cnf-conformance.yml
+++ b/sample-cnfs/sample_local_registry/cnf-conformance.yml
@@ -12,6 +12,6 @@ container_names:
   - name: coredns 
     rolling_update_test_tag: "1.8.0"
     rolling_downgrade_test_tag: 1.6.7
-    rolling_version_change_test_tag: latest
-    rollback_from_tag: latest
+    rolling_version_change_test_tag: 1.8.0
+    rollback_from_tag: 1.8.0
 white_list_helm_chart_container_names: []

--- a/spec/workload/configuration_lifecycle_spec.cr
+++ b/spec/workload/configuration_lifecycle_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/tasks/utils/kubectl_client.cr"
 require "colorize"
 
 describe CnfConformance do
@@ -101,6 +102,30 @@ describe CnfConformance do
       ensure
         LOGGING.info `./cnf-conformance cnf_cleanup cnf-config=./sample-cnfs/sample_coredns_invalid_version/cnf-conformance.yml deploy_with_chart=false`
       end
+    end
+    it "'#{tn}' should pass if using local registry and a port", tags: ["#{tn}"]  do
+      install_registry = `kubectl create -f #{TOOLS_DIR}/registry/manifest.yml`
+      install_dockerd = `kubectl create -f #{TOOLS_DIR}/dockerd/manifest.yml`
+      KubectlClient::Get.resource_wait_for_install("Pod", "registry")
+      KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
+      KubectlClient.exec("dockerd -ti -- docker pull coredns/coredns:1.6.7")
+      KubectlClient.exec("dockerd -ti -- docker tag coredns/coredns:1.6.7 registry:5000/coredns:1.6.7")
+      KubectlClient.exec("dockerd -ti -- docker push registry:5000/coredns:1.6.7")
+      KubectlClient.exec("dockerd -ti -- docker pull coredns/coredns:1.8.0")
+      KubectlClient.exec("dockerd -ti -- docker tag coredns/coredns:1.8.0 registry:5000/coredns:1.8.0")
+      KubectlClient.exec("dockerd -ti -- docker push registry:5000/coredns:1.8.0")
+
+      cnf="./sample-cnfs/sample_local_registry"
+
+      LOGGING.info `./cnf-conformance cnf_setup cnf-path=#{cnf}`
+      response_s = `./cnf-conformance #{tn} verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/Passed/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-conformance cnf_cleanup cnf-path=#{cnf}`
+      delete_registry = `kubectl delete -f #{TOOLS_DIR}/registry/manifest.yml`
+      delete_dockerd = `kubectl delete -f #{TOOLS_DIR}/dockerd/manifest.yml`
     end
   end
 

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -96,16 +96,26 @@ module KubectlClient
   end
   module Set
     def self.image(deployment_name, container_name, image_name, version_tag=nil)
-      LOGGING.debug "kubectl set deployment: #{deployment_name}, container: #{container_name} = image: #{image_name}, tag: #{version_tag}"
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
-      #TODO use process command to print both standard out and error
       if version_tag
+        LOGGING.debug "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record"
         # use --record to have history
-        resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record`
+        # resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record`
+        status = Process.run("kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record",
+                             shell: true,
+                             output: output = IO::Memory.new,
+                             error: stderr = IO::Memory.new)
       else
-        resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record`
+        LOGGING.debug "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record"
+        # resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record`
+        status = Process.run("kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record",
+                             shell: true,
+                             output: output = IO::Memory.new,
+                             error: stderr = IO::Memory.new)
       end
-      LOGGING.debug "kubectl set image: #{resp}"
+      LOGGING.info "KubectlClient.set image output: #{output.to_s}"
+      LOGGING.info "KubectlClient.set image stderr: #{stderr.to_s}"
+      # LOGGING.debug "kubectl set image: #{resp}"
       $?.success?
     end
   end

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -3,21 +3,21 @@ require "colorize"
 require "./cnf_manager.cr"
 require "halite"
 
-module KubectlClient 
-  WORKLOAD_RESOURCES = {deployment: "Deployment", 
-                        service: "Service", 
-                        pod: "Pod", 
-                        replicaset: "ReplicaSet", 
-                        statefulset: "StatefulSet", 
+module KubectlClient
+  WORKLOAD_RESOURCES = {deployment: "Deployment",
+                        service: "Service",
+                        pod: "Pod",
+                        replicaset: "ReplicaSet",
+                        statefulset: "StatefulSet",
                         daemonset: "DaemonSet"}
 
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
   def self.exec(command)
     LOGGING.info "KubectlClient.exec command: #{command}"
-    status = Process.run("kubectl exec #{command}", 
-                         shell: true, 
-                         output: output = IO::Memory.new, 
+    status = Process.run("kubectl exec #{command}",
+                         shell: true,
+                         output: output = IO::Memory.new,
                          error: stderr = IO::Memory.new)
     LOGGING.info "KubectlClient.exec output: #{output.to_s}"
     LOGGING.info "KubectlClient.exec stderr: #{stderr.to_s}"
@@ -25,9 +25,9 @@ module KubectlClient
   end
   def self.cp(command)
     LOGGING.info "KubectlClient.cp command: #{command}"
-    status = Process.run("kubectl cp #{command}", 
-                         shell: true, 
-                         output: output = IO::Memory.new, 
+    status = Process.run("kubectl cp #{command}",
+                         shell: true,
+                         output: output = IO::Memory.new,
                          error: stderr = IO::Memory.new)
     LOGGING.info "KubectlClient.cp output: #{output.to_s}"
     LOGGING.info "KubectlClient.cp stderr: #{stderr.to_s}"
@@ -35,7 +35,7 @@ module KubectlClient
   end
   module Rollout
     def self.status(deployment_name, timeout="30s")
-      #TODO use process command to print both standard out and error 
+      #TODO use process command to print both standard out and error
       rollout = `kubectl rollout status deployment/#{deployment_name} --timeout=#{timeout}`
       rollout_status = $?.success?
       LOGGING.debug "#{rollout}"
@@ -67,9 +67,9 @@ module KubectlClient
       # LOGGING.debug "apply? #{apply_status}"
       # apply_status
       LOGGING.info "apply file: #{file_name}"
-      status = Process.run("kubectl apply -f #{file_name}", 
-                           shell: true, 
-                           output: output = IO::Memory.new, 
+      status = Process.run("kubectl apply -f #{file_name}",
+                           shell: true,
+                           output: output = IO::Memory.new,
                            error: stderr = IO::Memory.new)
       LOGGING.info "KubectlClient.apply output: #{output.to_s}"
       LOGGING.info "KubectlClient.apply stderr: #{stderr.to_s}"
@@ -85,9 +85,9 @@ module KubectlClient
       # LOGGING.debug "delete? #{delete_status}"
       # delete_status
       # LOGGING.info "delete file: #{file_name}"
-      status = Process.run("kubectl delete -f #{file_name}", 
-                           shell: true, 
-                           output: output = IO::Memory.new, 
+      status = Process.run("kubectl delete -f #{file_name}",
+                           shell: true,
+                           output: output = IO::Memory.new,
                            error: stderr = IO::Memory.new)
       LOGGING.info "KubectlClient.delete output: #{output.to_s}"
       LOGGING.info "KubectlClient.delete stderr: #{stderr.to_s}"
@@ -96,19 +96,20 @@ module KubectlClient
   end
   module Set
     def self.image(deployment_name, container_name, image_name, version_tag=nil)
+      LOGGING.debug "set container: #{container_name} = image: #{image_name}, tag: #{version_tag}"
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
-      #TODO use process command to print both standard out and error 
+      #TODO use process command to print both standard out and error
       if version_tag
         # use --record to have history
         resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record`
       else
         resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record`
       end
-      LOGGING.debug "set image: #{resp}" 
+      LOGGING.debug "set image: #{resp}"
       $?.success?
     end
   end
-  module Get 
+  module Get
     def self.privileged_containers(namespace="--all-namespaces")
       privileged_response = `kubectl get pods #{namespace} -o jsonpath='{.items[*].spec.containers[?(@.securityContext.privileged==true)].name}'`
       # TODO parse this as json
@@ -145,7 +146,7 @@ module KubectlClient
       end
     end
 
-    def self.save_manifest(deployment_name, output_file) 
+    def self.save_manifest(deployment_name, output_file)
       resp = `kubectl get deployment #{deployment_name} -o yaml  > #{output_file}`
       LOGGING.debug "kubectl save_manifest: #{resp}"
       $?.success?
@@ -161,11 +162,11 @@ module KubectlClient
       end
     end
 
-    def self.deployment_containers(deployment_name) : JSON::Any 
+    def self.deployment_containers(deployment_name) : JSON::Any
       resource_containers("deployment", deployment_name)
     end
 
-    def self.resource_containers(kind, resource_name) : JSON::Any 
+    def self.resource_containers(kind, resource_name) : JSON::Any
       LOGGING.debug "kubectl get resource containers kind: #{kind} resource_name: #{resource_name}"
       unless kind.downcase == "service" ## services have no containers
         resp = resource(kind, resource_name).dig?("spec", "template", "spec", "containers")
@@ -178,7 +179,7 @@ module KubectlClient
       end
     end
 
-    def self.resource_volumes(kind, resource_name) : JSON::Any 
+    def self.resource_volumes(kind, resource_name) : JSON::Any
       LOGGING.debug "kubectl get resource volumes kind: #{kind} resource_name: #{resource_name}"
       unless kind.downcase == "service" ## services have no volumes
         resp = resource(kind, resource_name).dig?("spec", "template", "spec", "volumes")
@@ -216,13 +217,13 @@ module KubectlClient
     end
 
     def self.resource_wait_for_install(kind : String, resource_name : String, wait_count : Int32 = 180, namespace="default")
-      # Not all cnfs have #{kind}.  some have only a pod.  need to check if the 
-      # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod 
+      # Not all cnfs have #{kind}.  some have only a pod.  need to check if the
+      # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod
       LOGGING.info "resource_wait_for_install kind: #{kind} resource_name: #{resource_name} namespace: #{namespace}"
       second_count = 0
       pod_ready : String | Nil
-      current_replicas : String | Nil 
-      desired_replicas : String | Nil 
+      current_replicas : String | Nil
+      desired_replicas : String | Nil
       all_kind = `kubectl get #{kind} --namespace=#{namespace}`
       LOGGING.debug "all_kind #{all_kind}}"
       # Intialization
@@ -246,8 +247,8 @@ module KubectlClient
         LOGGING.debug "current_replicas #{current_replicas}"
       end
 
-        until (pod_ready && !pod_ready.empty? && pod_ready == "true") || 
-            (current_replicas && desired_replicas && !current_replicas.empty? && current_replicas.to_i == desired_replicas.to_i) || 
+        until (pod_ready && !pod_ready.empty? && pod_ready == "true") ||
+            (current_replicas && desired_replicas && !current_replicas.empty? && current_replicas.to_i == desired_replicas.to_i) ||
             second_count > wait_count
         LOGGING.info("second_count = #{second_count}")
         sleep 1
@@ -270,7 +271,7 @@ module KubectlClient
         LOGGING.debug "desired_replicas: #{desired_replicas}"
         LOGGING.debug "pod_read: #{pod_ready}"
         LOGGING.info(all_kind)
-        second_count = second_count + 1 
+        second_count = second_count + 1
       end
 
       if (pod_ready && !pod_ready.empty? && pod_ready == "true") ||
@@ -292,15 +293,15 @@ module KubectlClient
         sleep 1
         apply_resp = `kubectl apply -f #{manifest_file}`
         LOGGING.info("apply response: #{apply_resp}")
-        second_count = second_count + 1 
+        second_count = second_count + 1
       end
-    end 
+    end
 
     def self.resource_desired_is_available?(kind : String, resource_name)
       resp = `kubectl get #{kind} #{resource_name} -o=yaml`
       replicas_applicable = false
       case kind.downcase
-      when "deployment", "statefulset", "replicaset" 
+      when "deployment", "statefulset", "replicaset"
         replicas_applicable = true
         describe = Totem.from_yaml(resp)
         LOGGING.info("desired_is_available describe: #{describe.inspect}")
@@ -314,7 +315,7 @@ module KubectlClient
         end
         LOGGING.info("desired_is_available ready_replicas: #{ready_replicas}")
       else
-        replicas_applicable = false 
+        replicas_applicable = false
       end
       if replicas_applicable
         desired_replicas == ready_replicas
@@ -346,7 +347,7 @@ module KubectlClient
         LOGGING.info("I:#{i}")
         LOGGING.info("pod_name_prefix: #{pod_name_prefix}")
         if (acc[:name] =~ /#{pod_name_prefix}/).nil?
-          acc = {:name => "not found", :time => "not_found"} 
+          acc = {:name => "not found", :time => "not_found"}
         end
         if i[:name] =~ /#{pod_name_prefix}/
           acc = i
@@ -382,10 +383,10 @@ module KubectlClient
       status
     end
 
-    def self.deployment_spec_labels(deployment_name) : JSON::Any 
+    def self.deployment_spec_labels(deployment_name) : JSON::Any
       resource_spec_labels("deployment", deployment_name)
     end
-    def self.resource_spec_labels(kind, resource_name) : JSON::Any 
+    def self.resource_spec_labels(kind, resource_name) : JSON::Any
       LOGGING.debug "resource_labels kind: #{kind} resource_name: #{resource_name}"
       resp = resource(kind, resource_name).dig?("spec", "template", "metadata", "labels")
       LOGGING.debug "resource_labels: #{resp}"
@@ -396,13 +397,13 @@ module KubectlClient
       end
     end
 
-    def self.container_image_tags(deployment_containers) : Array(NamedTuple(image: String, 
+    def self.container_image_tags(deployment_containers) : Array(NamedTuple(image: String,
                                                                             tag: String | Nil))
       image_tags = deployment_containers.as_a.map do |container|
         LOGGING.debug "container (should have image and tag): #{container}"
-        {image: container.as_h["image"].as_s.split(":")[0],
+        {image: container.as_h["image"].as_s.rpartition(":")[0],
          #TODO an image may not have a tag
-         tag: container.as_h["image"].as_s.split(":")[1]?}
+         tag: container.as_h["image"].as_s.rpartition(":")[2]?}
       end
       LOGGING.debug "image_tags: #{image_tags}"
       image_tags
@@ -433,12 +434,12 @@ module KubectlClient
             nil
           end
         rescue ex
-          LOGGING.info ex.message 
+          LOGGING.info ex.message
           nil
         end
       end.compact
       LOGGING.debug "pv items : #{items}"
-      items 
+      items
     end
     def self.container_runtime
       nodes["items"][0]["status"]["nodeInfo"]["containerRuntimeVersion"].as_s
@@ -458,18 +459,18 @@ module KubectlClient
     end
 
     # *pod_exists* returns true if a pod containing *pod_name* exists, regardless of status.
-    # If *check_ready* is set to true, *pod_exists* validates that the pod exists and 
+    # If *check_ready* is set to true, *pod_exists* validates that the pod exists and
     # has a ready status of true
-    def self.pod_exists?(pod_name, check_ready=false, all_namespaces=false) 
+    def self.pod_exists?(pod_name, check_ready=false, all_namespaces=false)
       LOGGING.debug "pod_exists? pod_name: #{pod_name}"
       exists = pods(all_namespaces)["items"].as_a.any? do |x|
         (name_comparison = x["metadata"]["name"].as_s? =~ /#{pod_name}/
-        (x["metadata"]["name"].as_s? =~ /#{pod_name}/) || 
+        (x["metadata"]["name"].as_s? =~ /#{pod_name}/) ||
           (x["metadata"]["generateName"]? && x["metadata"]["generateName"].as_s? =~ /#{pod_name}/)) &&
         (check_ready && (x["status"]["conditions"].as_a.find{|x| x["type"].as_s? == "Ready"} && x["status"].as_s? == "True") || check_ready==false)
       end
       LOGGING.debug "pod exists: #{exists}"
-      exists 
+      exists
     end
     def self.all_pod_statuses
       statuses = pods["items"].as_a.map do |x|

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -96,7 +96,7 @@ module KubectlClient
   end
   module Set
     def self.image(deployment_name, container_name, image_name, version_tag=nil)
-      LOGGING.debug "set container: #{container_name} = image: #{image_name}, tag: #{version_tag}"
+      LOGGING.debug "kubectl set deployment: #{deployment_name}, container: #{container_name} = image: #{image_name}, tag: #{version_tag}"
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
       #TODO use process command to print both standard out and error
       if version_tag
@@ -105,7 +105,7 @@ module KubectlClient
       else
         resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record`
       end
-      LOGGING.debug "set image: #{resp}"
+      LOGGING.debug "kubectl set image: #{resp}"
       $?.success?
     end
   end
@@ -372,7 +372,10 @@ module KubectlClient
       # pod = all_pod_names[time_stamps.index(latest_time).not_nil!]
       # pod = all_pods.select{ | x | x =~ /#{pod_name_prefix}/ }
       puts "Pods Found: #{pod}"
-      status = `kubectl get pods #{pod} -o jsonpath='{.metadata.name},{.status.phase},{.status.containerStatuses[*].ready}'`
+      status = false
+      if #{pod} != "not found"
+        status = `kubectl get pods #{pod} -o jsonpath='{.metadata.name},{.status.phase},{.status.containerStatuses[*].ready}'`
+      end
       status
     end
 

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -160,6 +160,7 @@ rolling_version_change_test_names.each do |tn|
         unless rollout_status
           test_passed = false
         end
+        test_passed
       end
       if task_response
         resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed" )

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -134,13 +134,14 @@ rolling_version_change_test_names.each do |tn|
 
       task_response = update_applied && CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
         test_passed = true
+        valid_cnf_conformance_yml = true
         LOGGING.debug "#{tn} container: #{container}"
         LOGGING.debug "container_names: #{container_names}"
         config_container = container_names.find{|x| x["name"]==container.as_h["name"]} if container_names
         LOGGING.debug "config_container: #{config_container}"
         unless config_container && config_container["#{tn}_test_tag"]? && !config_container["#{tn}_test_tag"].empty?
           puts "Please add the container name #{container.as_h["name"]} and a corresponding #{tn}_test_tag into your cnf-conformance.yml under container names".colorize(:red)
-          # valid_cnf_conformance_yml = false
+          valid_cnf_conformance_yml = false
         end
 
         if valid_cnf_conformance_yml && config_container

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -62,17 +62,17 @@ task "liveness" do |_, args|
       test_passed = true
       begin
         VERBOSE_LOGGING.debug container.as_h["name"].as_s if check_verbose(args)
-        container.as_h["livenessProbe"].as_h 
+        container.as_h["livenessProbe"].as_h
       rescue ex
         VERBOSE_LOGGING.error ex.message if check_verbose(args)
-        test_passed = false 
+        test_passed = false
         puts "No livenessProbe found for resource: #{resource} and container: #{container.as_h["name"].as_s}".colorize(:red)
       end
       LOGGING.debug "liveness test_passed: #{test_passed}"
-      test_passed 
+      test_passed
     end
     LOGGING.debug "liveness task response: #{task_response}"
-    if task_response 
+    if task_response
       resp = upsert_passed_task("liveness","✔️  PASSED: Helm liveness probe found #{emoji_probe}")
 		else
 			resp = upsert_failed_task("liveness","✖️  FAILURE: No livenessProbe found #{emoji_probe}")
@@ -93,15 +93,15 @@ task "readiness" do |_, args|
       test_passed = true
       begin
         VERBOSE_LOGGING.debug container.as_h["name"].as_s if check_verbose(args)
-        container.as_h["readinessProbe"].as_h 
+        container.as_h["readinessProbe"].as_h
       rescue ex
         VERBOSE_LOGGING.error ex.message if check_verbose(args)
-        test_passed = false 
+        test_passed = false
         puts "No readinessProbe found for resource: #{resource} and container: #{container.as_h["name"].as_s}".colorize(:red)
       end
-      test_passed 
+      test_passed
     end
-    if task_response 
+    if task_response
       resp = upsert_passed_task("readiness","✔️  PASSED: Helm readiness probe found #{emoji_probe}")
 		else
       resp = upsert_failed_task("readiness","✖️  FAILURE: No readinessProbe found #{emoji_probe}")
@@ -123,7 +123,7 @@ rolling_version_change_test_names.each do |tn|
       LOGGING.debug "container_names: #{container_names}"
       update_applied = true
       unless container_names
-        puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) 
+        puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red)
         update_applied = false
       end
 
@@ -143,30 +143,30 @@ rolling_version_change_test_names.each do |tn|
           # valid_cnf_conformance_yml = false
         end
 
-        if config_container
-          resp = KubectlClient::Set.image(resource["name"], 
-                                          container.as_h["name"], 
+        if valid_cnf_conformance_yml && config_container
+          resp = KubectlClient::Set.image(resource["name"],
+                                          container.as_h["name"],
                                           # split out image name from version tag
-                                          container.as_h["image"].as_s.split(":")[0], 
-                                          config_container["rolling_update_test_tag"]) 
-        else 
+                                          container.as_h["image"].as_s.rpartition(":")[0],
+                                          config_container["#{tn}_test_tag"])
+        else
           resp = false
         end
         # If any containers dont have an update applied, fail
         test_passed = false if resp == false
 
         rollout_status = KubectlClient::Rollout.resource_status(resource["kind"], resource["name"])
-        unless rollout_status 
+        unless rollout_status
           test_passed = false
         end
       end
-      if task_response 
+      if task_response
         resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed" )
       else
         resp = upsert_failed_task("#{tn}", "✖️  FAILURE: CNF for #{pretty_test_name_capitalized} Failed")
       end
       resp
-      # TODO should we roll the image back to original version in an ensure? 
+      # TODO should we roll the image back to original version in an ensure?
       # TODO Use the kubectl rollback to history command
     end
   end
@@ -183,27 +183,34 @@ task "rollback" do |_, args|
 
     update_applied = true
     rollout_status = true
-    rollback_status = true 
-    version_change_applied = true 
+    rollback_status = true
+    version_change_applied = true
 
     unless container_names
-      puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red) 
+      puts "Please add a container names set of entries into your cnf-conformance.yml".colorize(:red)
       update_applied = false
     end
 
     task_response = update_applied && CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
 
 
-        image_name = container.as_h["name"]
-        image_tag = container.as_h["image"].as_s.split(":")[0]
+        container_name = container.as_h["name"]
+        image_name = container.as_h["image"].as_s.rpartition(":")[0]
+        image_tag = container.as_h["image"].as_s.rpartition(":")[2]
 
+        VERBOSE_LOGGING.debug "container_name: #{container_name}" if check_verbose(args)
         VERBOSE_LOGGING.debug "image_name: #{image_name}" if check_verbose(args)
-        VERBOSE_LOGGING.debug "rollback: setting new version" if check_verbose(args)
+        VERBOSE_LOGGING.debug "image_tag: #{image_tag}" if check_verbose(args)
+        LOGGING.debug "rollback: setting new version"
         #do_update = `kubectl set image deployment/coredns-coredns coredns=coredns/coredns:latest --record`
 
-        version_change_applied = false 
-        config_container = container_names.find{|x| x["name"] == image_name } if container_names
-        if config_container
+        version_change_applied = false
+        config_container = container_names.find{|x| x["name"] == container_name } if container_names
+        unless config_container && config_container["rollback_from_tag"]? && !config_container["rollback_from_tag"].empty?
+          puts "Please add the container name #{container.as_h["name"]} and a corresponding rollback_from_tag into your cnf-conformance.yml under container names".colorize(:red)
+          version_change_applied = false
+        end
+        if version_change_applied && config_container
           rollback_from_tag = config_container["rollback_from_tag"]
 
           if rollback_from_tag == image_tag
@@ -212,10 +219,10 @@ task "rollback" do |_, args|
             version_change_applied=false
           end
 
-          version_change_applied = KubectlClient::Set.image(resource["name"], 
-                                                            image_name, 
-                                                            image_tag, 
-                                                            rollback_from_tag) 
+          version_change_applied = KubectlClient::Set.image(resource["name"],
+                                                            container_name,
+                                                            image_name,
+                                                            rollback_from_tag)
         end
 
         VERBOSE_LOGGING.debug "change successful? #{version_change_applied}" if check_verbose(args)
@@ -252,15 +259,15 @@ task "nodeport_not_used" do |_, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false, check_service: true) do |resource, container, initialized|
       LOGGING.info "nodeport_not_used resource: #{resource}"
-      if resource["kind"].as_s.downcase == "service" 
+      if resource["kind"].as_s.downcase == "service"
         LOGGING.info "resource kind: #{resource}"
         service = KubectlClient::Get.resource(resource[:kind], resource[:name])
         LOGGING.debug "service: #{service}"
-        service_type = service.dig?("spec", "type") 
+        service_type = service.dig?("spec", "type")
         LOGGING.info "service_type: #{service_type}"
         VERBOSE_LOGGING.debug service_type if check_verbose(args)
-        if service_type == "NodePort" 
-          #TODO make a service selector and display the related resources 
+        if service_type == "NodePort"
+          #TODO make a service selector and display the related resources
           # that are tied to this service
           puts "resource service: #{resource} has a NodePort that is being used".colorize(:red)
           test_passed=false
@@ -268,7 +275,7 @@ task "nodeport_not_used" do |_, args|
         test_passed
       end
     end
-    if task_response 
+    if task_response
       upsert_passed_task("nodeport_not_used", "✔️  PASSED: NodePort is not used")
     else
       upsert_failed_task("nodeport_not_used", "✖️  FAILURE: NodePort is being used")
@@ -301,7 +308,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     ip_search = File.read_lines("#{destination_cnf_dir}/helm_chart.yml").take_while{|x| x.match(/NOTES:/) == nil}.reduce([] of String){|acc, x| x.match(/([0-9]{1,3}[\.]){3}[0-9]{1,3}/) && x.match(/([0-9]{1,3}[\.]){3}[0-9]{1,3}/).try &.[0] != "0.0.0.0" ? acc << x : acc}
     VERBOSE_LOGGING.info "IPs: #{ip_search}" if check_verbose(args)
 
-    if ip_search.empty? 
+    if ip_search.empty?
       upsert_passed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✔️  PASSED: No hard-coded IP addresses found in the runtime K8s configuration")
     else
       upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  FAILURE: Hard-coded IP addresses found in the runtime K8s configuration")
@@ -325,21 +332,21 @@ task "secrets_used" do |_, args|
 
       volume_test_passed = false
       secret_volume_exists = false
-      secret_volume_mounted = true 
+      secret_volume_mounted = true
       # Check to see all volume secrets are actually used
       volumes.as_a.each do |secret_volume|
         if secret_volume["secret"]?
-          secret_volume_exists = true 
+          secret_volume_exists = true
           LOGGING.info "secret_volume: #{secret_volume["name"]}"
-          container_secret_mounted = false 
+          container_secret_mounted = false
           containers.as_a.each do |container|
             if container["volumeMounts"]?
                 vmount = container["volumeMounts"].as_a
               LOGGING.info "vmount: #{vmount}"
               LOGGING.debug "container[env]: #{container["env"]}"
-              if (vmount.find { |x| x["name"] == secret_volume["name"]? }) 
+              if (vmount.find { |x| x["name"] == secret_volume["name"]? })
                 LOGGING.debug secret_volume["name"]
-                container_secret_mounted = true 
+                container_secret_mounted = true
               end
             end
           end
@@ -354,33 +361,33 @@ task "secrets_used" do |_, args|
         volume_test_passed = true
       end
 
-      
-      # TODO if a container exists which has a secretkeyref defined 
+
+      # TODO if a container exists which has a secretkeyref defined
       # and also has a corresponding k8s secret defined, the whole test passes.
 
-      #  if there are any containers that have a secretkeyref defined 
-      #  but do not have a corresponding k8s secret defined, this 
+      #  if there are any containers that have a secretkeyref defined
+      #  but do not have a corresponding k8s secret defined, this
       #  is an installation problem, and does not stop the test from passing
 
       secrets = KubectlClient::Get.secrets
-      secret_keyref_found = false 
+      secret_keyref_found = false
       containers.as_a.each do |container|
         LOGGING.debug "container secrets #{container["env"]?}"
-        if container["env"]? 
-          container["env"].as_a.find do |c| 
+        if container["env"]?
+          container["env"].as_a.find do |c|
           if secrets["items"].as_a.find{|s|
               s["metadata"]["name"] == c.dig?("valueFrom", "secretKeyRef", "name")}
               secret_keyref_found = true
             end
           end
-        end 
+        end
       end
 
       # if at least 1 secret volume exists, and it is mounted, test passes
       # if at least 1 secret volume exists, but it is not mounted, test fails
-      # if no secret volumes exist, but a container secret exists 
+      # if no secret volumes exist, but a container secret exists
       #  and is defined, test passes
-      # if at least 1 container secret exists, but it is not defined, this 
+      # if at least 1 container secret exists, but it is not defined, this
       # is an installation problem
       # if no secret volume exists and no container secret exists, test fails
       test_passed = false
@@ -388,12 +395,12 @@ task "secrets_used" do |_, args|
         test_passed = true
       end
 
-      unless test_passed 
+      unless test_passed
         puts "No Secret Volumes or Container secretKey_refs found for resource: #{resource}".colorize(:red)
       end
-      test_passed 
+      test_passed
     end
-    if task_response 
+    if task_response
       resp = upsert_passed_task("secrets_used","✔️  PASSED: Secret Volume found #{emoji_probe}")
     else
       resp = upsert_failed_task("secrets_used","✖️  FAILURE: Secret Volume not found #{emoji_probe}")
@@ -424,7 +431,7 @@ task "immutable_configmap" do |_, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
 
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
-    
+
     # feature test to see if immutable_configmaps are enabled
     # https://github.com/cncf/cnf-conformance/issues/508#issuecomment-758438413
 
@@ -453,7 +460,7 @@ task "immutable_configmap" do |_, args|
     end
 
     # cleanup test configmap
-    KubectlClient::Delete.file(test_config_map_filename) 
+    KubectlClient::Delete.file(test_config_map_filename)
 
     resp = ""
     emoji_probe="⚖️"
@@ -465,23 +472,23 @@ task "immutable_configmap" do |_, args|
 
       volume_test_passed = false
       config_map_volume_exists = false
-      config_map_volume_mounted = true 
+      config_map_volume_mounted = true
       all_volume_configmap_are_immutable = true
       # Check to see all volume config maps are actually used
       # https://kubernetes.io/docs/concepts/storage/volumes/#configmap
       volumes.as_a.each do |config_map_volume|
         if config_map_volume["configMap"]?
-          config_map_volume_exists = true 
+          config_map_volume_exists = true
           LOGGING.info "config_map_volume: #{config_map_volume["name"]}"
-          container_config_map_mounted = false 
+          container_config_map_mounted = false
           containers.as_a.each do |container|
             if container["volumeMounts"]?
                 vmount = container["volumeMounts"].as_a
               LOGGING.info "vmount: #{vmount}"
               LOGGING.debug "container[env]: #{container["env"]? && container["env"]}"
-              if (vmount.find { |x| x["name"] == config_map_volume["name"]? }) 
+              if (vmount.find { |x| x["name"] == config_map_volume["name"]? })
                 LOGGING.debug config_map_volume["name"]
-                container_config_map_mounted = true 
+                container_config_map_mounted = true
               end
             end
           end
@@ -512,8 +519,8 @@ task "immutable_configmap" do |_, args|
 
       containers.as_a.each do |container|
         LOGGING.debug "container config_maps #{container["env"]?}"
-        if container["env"]? 
-          container["env"].as_a.find do |c| 
+        if container["env"]?
+          container["env"].as_a.find do |c|
 
           # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#define-container-environment-variables-with-data-from-multiple-configmaps
           this_env_mounted_config_map_name = c.dig?("valueFrom", "configMapKeyRef", "name")
@@ -525,13 +532,13 @@ task "immutable_configmap" do |_, args|
               all_env_configmap_are_immutable = false
             end
           end
-        end 
+        end
       end
 
       all_volume_configmap_are_immutable && all_env_configmap_are_immutable
     end
 
-    if cnf_manager_workload_resource_task_response 
+    if cnf_manager_workload_resource_task_response
       resp = "✔️  PASSED: All volume or container mounted configmaps immutable #{emoji_probe}".colorize(:green)
       upsert_passed_task("immutable_configmap", resp)
     else

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -128,36 +128,6 @@ task "reasonable_image_size", ["install_dockerd"] do |_, args|
 				fqdn_image = container.as_h["image"].as_s
         # parsed_image = DockerClient.parse_image(fqdn_image)
 
-        LOGGING.info "fqdn_image: #{fqdn_image}"
-        case fqdn_image.split("/").size
-        when 3
-          org_image = "#{fqdn_image.split("/")[1]}/#{fqdn_image.split("/")[2]}"
-          org = fqdn_image.split("/")[1]
-          image =  fqdn_image.split("/")[2]
-        when 2
-          # TODO if there is a port in the first element, it is not an org, but a url
-
-          org_image = "#{fqdn_image.split("/")[0]}/#{fqdn_image.split("/")[1]}"
-          org = fqdn_image.split("/")[0]
-          image =  fqdn_image.split("/")[1]
-        when 1
-          org_image = fqdn_image.split("/")[0]
-          org = ""
-          image =  fqdn_image.split("/")[0]
-        else
-          org_image = ""
-          org = ""
-          image =  ""
-          LOGGING.error "Invalid container image name"
-        end
-        LOGGING.info "org_image: #{org_image}"
-        LOGGING.info "org: #{org}"
-        LOGGING.info "image: #{image}"
-        local_image_tag = {image: image.rpartition(":")[0],
-                           #TODO an image may not have a tag
-                           tag: image.rpartition(":")[2]?}
-        LOGGING.info "local_image_tag: #{local_image_tag}"
-
         image_pull_secrets = KubectlClient::Get.resource(resource[:kind], resource[:name]).dig?("spec", "template", "spec", "imagePullSecrets")
         if image_pull_secrets
           auths = image_pull_secrets.as_a.map { |secret|


### PR DESCRIPTION
# [BUG] rollback, rolling_version_change tests do not handle images that use a local registry with port

## Description
[BUG] rollback, rolling_version_change tests do not handle images that use a local registry with port

## Issues:
Refs: #635

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
