### PR TITLE
[BUG] reasonable_image_size test should not fail if dockerd is not installed or if docker command fails

### DIFF
--- a/spec/cnf_conformance_all/cnf_conformance_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_spec.cr
@@ -28,7 +28,7 @@ describe CnfConformance do
     (/PASSED: Published Helm Chart Found/ =~ response_s).should_not be_nil
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil
-    (CNFManager::Points.all_result_test_names(CNFManager::Points.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used",  "pod_network_latency", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published", "reasonable_image_size", "rollback", "secrets_used", "immutable_configmap"].sort)
+    (CNFManager::Points.all_result_test_names(CNFManager::Points.final_cnf_results_yml).sort).should eq(["volume_hostpath_not_found", "privileged", "increase_capacity", "decrease_capacity", "ip_addresses", "liveness", "readiness", "reasonable_startup_time", "rolling_update", "rolling_downgrade", "rolling_version_change", "nodeport_not_used",  "pod_network_latency", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "install_script_helm", "helm_chart_valid", "helm_chart_published", "reasonable_image_size", "rollback", "secrets_used", "immutable_configmap"].sort)
     (/^.*\.cr:[0-9].*/ =~ response_s).should be_nil
     $?.success?.should be_true
   end

--- a/src/tasks/dockerd_setup.cr
+++ b/src/tasks/dockerd_setup.cr
@@ -7,8 +7,6 @@ require "./utils/utils.cr"
 desc "The dockerd tool is used to run docker commands against the cluster."
 task "install_dockerd" do |_, args|
   VERBOSE_LOGGING.info "install_dockerd" if check_verbose(args)
-  #TODO used process command to remove command line noise
-  # install_dockerd = `kubectl create -f #{TOOLS_DIR}/dockerd/manifest.yml`
   status = Process.run("kubectl create -f #{TOOLS_DIR}/dockerd/manifest.yml",
                                 shell: true,
                                 output: install_dockerd = IO::Memory.new,
@@ -16,9 +14,8 @@ task "install_dockerd" do |_, args|
   LOGGING.info "Dockerd_Install output: #{install_dockerd.to_s}"
   LOGGING.info "Dockerd_Install stderr: #{stderr.to_s}"
   LOGGING.info "Dockerd_Install status: #{status}"
+  status = check_dockerd
   if status
-    status = KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
-  else
     LOGGING.error "Dockerd_Install failed: #{stderr.to_s}".colorize(:red)
   end
   LOGGING.info "Dockerd_Install status: #{status}"
@@ -32,3 +29,6 @@ task "uninstall_dockerd" do |_, args|
   LOGGING.debug "Dockerd_uninstall: #{delete_dockerd}"
 end
 
+def check_dockerd
+  KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
+end

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -258,7 +258,7 @@ end
 
 def upsert_skipped_task(task, message)
  CNFManager::Points.upsert_task(task, SKIPPED, CNFManager::Points.task_points(task, CNFManager::Points::Results::ResultStatus::Skipped))
-  stdout_success message
+  stdout_warning message
   message
 end
 

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -16,8 +16,7 @@ end
 desc "Does the CNF have a reasonable startup time?"
 task "reasonable_startup_time" do |_, args|
   unless check_destructive(args)
-    LOGGING.info "skipping reasonable_startup_time: not in destructive mode"
-    puts "Skipped".colorize(:yellow)
+    upsert_skipped_task("reasonable_startup_time", "✖️  SKIPPED: skipping reasonable_startup_time: not in destructive mode")
     next
   end
   LOGGING.info "Running reasonable_startup_time in destructive mode!"
@@ -110,8 +109,11 @@ task "reasonable_startup_time" do |_, args|
 end
 
 desc "Does the CNF have a reasonable container image size?"
-#TODO Move install_dockerd dep out.
 task "reasonable_image_size", ["install_dockerd"] do |_, args|
+  unless check_dockerd
+    upsert_skipped_task("reasonable_image_size", "✖️  SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install")
+    next
+  end
   CNFManager::Task.task_runner(args) do |args,config|
     VERBOSE_LOGGING.info "reasonable_image_size" if check_verbose(args)
     LOGGING.debug "cnf_config: #{config}"


### PR DESCRIPTION
## Description
[BUG] reasonable_image_size test should not fail if dockerd is not installed or if docker command fails

## Issues:
Refs: #645

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
