### PR TITLE
Feat(resiliency): Add litmus disk fill chaos test

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -469,6 +469,11 @@ crystal src/cnf-conformance.cr performance
 ./cnf-conformance pod_network_latency
 ```
 
+#### :heavy_check_mark: Test if the CNF crashes when disk fill occurs 
+```
+./cnf-conformance disk_fill
+```
+
 ---
 ### Platform Tests
 ####  :heavy_check_mark: Run all platform tests

--- a/points.yml
+++ b/points.yml
@@ -48,6 +48,8 @@
   tags: scalability, dynamic, workload
 - name: pod_network_latency
   tags: scalability, dynamic, workload
+- name: disk_fill
+  tags: scalability, dynamic, workload  
 #- name: external_retry 
 #  tags: scalability, dynamic, workload
 

--- a/scoring_config/points_v1.yml
+++ b/scoring_config/points_v1.yml
@@ -108,6 +108,9 @@
   tags: workload, resilience, dynamic
 - name: chaos_container_kill
   tags: workload, resilience, dynamic
+- name: disk_fill
+  tags: scalability, dynamic, workload
+
 
 - name: hardware_and_scheduling
   tags: workload, hardware, dynamic

--- a/spec/cnf_conformance_all/cnf_conformance_config_lifecycle_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_config_lifecycle_spec.cr
@@ -15,7 +15,7 @@ describe CnfConformance do
 
  it "'conformance all' should run the configuration lifecycle tests", tags: ["conformance-config-lifecycle"] do
     `./cnf-conformance samples_cleanup`
-    response_s = `./cnf-conformance all ~reasonable_startup_time ~reasonable_image_size ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
+    response_s = `./cnf-conformance all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
     LOGGING.info response_s
     (/PASSED: Helm readiness probe found/ =~ response_s).should_not be_nil
     (/PASSED: Helm liveness probe/ =~ response_s).should_not be_nil

--- a/spec/cnf_conformance_all/cnf_conformance_microservice_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_microservice_spec.cr
@@ -15,7 +15,7 @@ describe CnfConformance do
 
   it "'conformance all' should run all the microservice tests", tags: ["conformance-microservice"] do
     `./cnf-conformance samples_cleanup`
-    response_s = `./cnf-conformance all ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
+    response_s = `./cnf-conformance all ~disk_fill ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
     LOGGING.info response_s
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/cnf_conformance_all/cnf_conformance_spec.cr
+++ b/spec/cnf_conformance_all/cnf_conformance_spec.cr
@@ -18,7 +18,7 @@ describe CnfConformance do
     # the workload resilience tests are run in the chaos specs
     # the ommisions (i.e. ~resilience) are done for performance reasons for the spec suite
     # response_s = `./cnf-conformance all ~platform ~resilience cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose`
-    response_s = `./cnf-conformance all ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
+    response_s = `./cnf-conformance all ~disk_fill ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml" verbose`
     LOGGING.info response_s
     (/Lint Passed/ =~ response_s).should_not be_nil
     (/PASSED: Replicas increased to 3/ =~ response_s).should_not be_nil

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -100,7 +100,7 @@ describe "SampleUtils" do
 
   it "'CNFManager::Points.all_task_test_names' should return all tasks names", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-    (CNFManager::Points.all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "pod_network_latency", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "rollback", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "secrets_used", "immutable_configmap" , "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found", "no_local_volume_configuration"])
+    (CNFManager::Points.all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "pod_network_latency", "disk_fill", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "rollback", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "secrets_used", "immutable_configmap" , "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found", "no_local_volume_configuration"])
   end
 
   it "'CNFManager::Points.all_result_test_names' should return the tasks assigned to a tag", tags: ["points"] do

--- a/spec/workload/resilience/disk_fill_spec.cr
+++ b/spec/workload/resilience/disk_fill_spec.cr
@@ -19,7 +19,7 @@ describe "Resilience Disk Fill Chaos" do
       response_s = `./cnf-conformance disk_fill verbose`
       LOGGING.info response_s
       $?.success?.should be_true
-      (/PASSED: disk-fill chaos test passed/ =~ response_s).should_not be_nil
+      (/PASSED: disk_fill chaos test passed/ =~ response_s).should_not be_nil
     ensure
       `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
       $?.success?.should be_true

--- a/spec/workload/resilience/disk_fill_spec.cr
+++ b/spec/workload/resilience/disk_fill_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/tasks/utils/utils.cr"
+require "../../../src/tasks/utils/system_information/helm.cr"
+require "file_utils"
+require "sam"
+
+describe "Resilience Disk Fill Chaos" do
+  before_all do
+    `./cnf-conformance setup`
+    `./cnf-conformance configuration_file_setup`
+    $?.success?.should be_true
+  end
+
+  it "'disk_fill' A 'Good' CNF should not crash when disk fill occurs", tags: ["disk_fill"]  do
+    begin
+      `./cnf-conformance cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
+      $?.success?.should be_true
+      response_s = `./cnf-conformance disk_fill verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: disk-fill chaos test passed/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-conformance cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-conformance.yml`
+      $?.success?.should be_true
+      `./cnf-conformance uninstall_litmus`
+      $?.success?.should be_true
+    end
+  end
+end

--- a/src/tasks/litmus_cleanup.cr
+++ b/src/tasks/litmus_cleanup.cr
@@ -7,7 +7,7 @@ require "./utils/utils.cr"
 desc "Uninstall LitmusChaos"
 task "uninstall_litmus" do |_, args|
     uninstall_chaosengine = `kubectl delete chaosengine --all --all-namespaces`
-    litmus_uninstall = `kubectl delete -f https://litmuschaos.github.io/litmus/litmus-operator-v1.11.0.yaml`
+    litmus_uninstall = `kubectl delete -f https://litmuschaos.github.io/litmus/litmus-operator-v1.13.2.yaml`
     puts "#{uninstall_chaosengine}" if check_verbose(args)
     puts "#{litmus_uninstall}" if check_verbose(args)
 end

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -7,7 +7,7 @@ require "./utils/utils.cr"
 desc "Install LitmusChaos"
 task "install_litmus" do |_, args|
     # litmus_install = `kubectl apply -f https://litmuschaos.github.io/litmus/litmus-operator-v1.11.0.yaml`
-    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.11.0.yaml")
+    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.2.yaml")
     # puts "#{litmus_install}" if check_verbose(args)
 end
 

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -6,7 +6,7 @@ require "../utils/utils.cr"
 
 desc "The CNF conformance suite checks to see if the CNFs are resilient to failures."
 #task "resilience", ["chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill" ] do |t, args|
- task "resilience", ["pod_network_latency", "chaos_cpu_hog", "chaos_container_kill"] do |t, args|
+ task "resilience", ["pod_network_latency", "chaos_cpu_hog", "chaos_container_kill", "disk_fill"] do |t, args|
   VERBOSE_LOGGING.info "resilience" if check_verbose(args)
   VERBOSE_LOGGING.debug "resilience args.raw: #{args.raw}" if check_verbose(args)
   VERBOSE_LOGGING.debug "resilience args.named: #{args.named}" if check_verbose(args)

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -183,9 +183,9 @@ task "pod_network_latency", ["install_litmus"] do |_, args|
         test_passed = false
       end
       if test_passed
-        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/experiment.yaml")
+        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/pod-network-latency/experiment.yaml")
         # install_experiment = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/experiment.yaml`
-        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/rbac.yaml")
+        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/pod-network-latency/rbac.yaml")
         # install_rbac = `kubectl apply -f https://hub.litmuschaos.io/api/chaos/1.11.1?file=charts/generic/pod-network-latency/rbac.yaml`
         annotate = `kubectl annotate --overwrite deploy/#{resource["name"]} litmuschaos.io/chaos="true"`
         # puts "#{install_experiment}" if check_verbose(args)
@@ -211,6 +211,46 @@ task "pod_network_latency", ["install_litmus"] do |_, args|
       resp = upsert_passed_task("pod_network_latency","✔️  PASSED: pod_network_latency chaos test passed 🗡️💀♻️")
     else
       resp = upsert_failed_task("pod_network_latency","✖️  FAILED: pod_network_latency chaos test failed 🗡️💀♻️")
+    end
+    resp
+  end
+end
+
+desc "Does the CNF crash when disk fill occurs"
+task "disk_fill", ["install_litmus"] do |_, args|
+  CNFManager::Task.task_runner(args) do |args, config|
+    VERBOSE_LOGGING.info "disk_fill" if check_verbose(args)
+    LOGGING.debug "cnf_config: #{config}"
+    destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.size > 0
+        test_passed = true
+      else
+        puts "No resource label found for disk_fill test for resource: #{resource["name"]}".colorize(:red)
+        test_passed = false
+      end
+      if test_passed
+        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/disk-fill/experiment.yaml")
+        KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/1.13.2?file=charts/generic/disk-fill/rbac.yaml")
+        annotate = `kubectl annotate --overwrite deploy/#{resource["name"]} litmuschaos.io/chaos="true"`
+
+        chaos_experiment_name = "disk-fill"
+        test_name = "#{resource["name"]}-#{Random.rand(99)}" 
+        chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
+
+        template = Crinja.render(chaos_template_disk_fill, {"chaos_experiment_name"=> "#{chaos_experiment_name}", "deployment_label" => "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_key}", "deployment_label_value" => "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_value}", "test_name" => test_name})
+        chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
+        puts "#{chaos_config}" if check_verbose(args)
+        KubectlClient::Apply.file("#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml")
+        LitmusManager.wait_for_test(test_name,chaos_experiment_name,args)
+        LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)
+      end
+      test_passed
+    end
+    if task_response 
+      resp = upsert_passed_task("disk_fill","✔️  PASSED: disk_fill chaos test passed 🗡️💀♻️")
+    else
+      resp = upsert_failed_task("disk_fill","✖️  FAILED: disk_fill chaos test failed 🗡️💀♻️")
     end
     resp
   end
@@ -336,3 +376,42 @@ def chaos_template_pod_network_latency
 
   TEMPLATE
   end
+
+  def chaos_template_disk_fill
+    <<-TEMPLATE
+    apiVersion: litmuschaos.io/v1alpha1
+    kind: ChaosEngine
+    metadata:
+      name: {{ test_name }}
+      namespace: default
+    spec:
+      annotationCheck: 'true'
+      engineState: 'active'
+      auxiliaryAppInfo: ''
+      appinfo:
+        appns: 'default'
+        applabel: '{{ deployment_label}}={{ deployment_label_value }}'
+        appkind: 'deployment'
+      chaosServiceAccount: {{ chaos_experiment_name }}-sa
+      monitoring: false
+      jobCleanUpPolicy: 'delete'
+      experiments:
+        - name: {{ chaos_experiment_name }}
+          spec:
+            components:
+              env:
+                # specify the fill percentage according to the disk pressure required
+                - name: EPHEMERAL_STORAGE_MEBIBYTES
+                  value: '500'
+                  
+                - name: TARGET_CONTAINER
+                  value: '' 
+
+                - name: FILL_PERCENTAGE
+                  value: ''
+
+                - name: CONTAINER_PATH
+                  value: '/var/lib/containerd/io.containerd.grpc.v1.cri/containers/'
+                              
+    TEMPLATE
+    end


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

## Description
- This PR adds a litmus disk fill chaos experiment to check the resiliency of the CNF application when subject to disk stress for a certain amount of given memory either in the percentage of total ephemeral-storage limit or the memory in Mi unit. It can also be used to test the Ephemeral Storage Limits, to ensure those parameters are sufficient and the application's resiliency to disk stress/replica evictions. For More information checkout [experiment docs](https://docs.litmuschaos.io/docs/disk-fill/).

-  This PR also update the litmus version and pod network latency chaos version to`1.13.2` (which is the latest as of now).  

- Check out the test logs [here](https://github.com/cncf/cnf-conformance/issues/499#issuecomment-801415239).

## Issues:
Refs: #499 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
