### PR TITLE
[BUG] tags for points.yml scores are getting added for workload reslilience tests when they're tagged as platform:resilience

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -98,6 +98,12 @@ describe "SampleUtils" do
     (CNFManager::Points.tasks_by_tag("does-not-exist")).should eq([] of YAML::Any) 
   end
 
+  it "'CNFManager::Points.tasks_by_tag' should only return the tasks that are within their category ", tags: ["points"] do
+    CNFManager::Points.clean_results_yml
+    (CNFManager::Points.tasks_by_tag("resilience").
+     find{|x| x=="worker_reboot_recovery"}).should be_nil
+  end
+
   it "'CNFManager::Points.all_task_test_names' should return all tasks names", tags: ["points"] do
     CNFManager::Points.clean_results_yml
     (CNFManager::Points.all_task_test_names()).should eq(["reasonable_image_size", "reasonable_startup_time", "privileged", "increase_capacity", "decrease_capacity", "network_chaos", "pod_network_latency", "disk_fill", "ip_addresses", "liveness", "readiness", "rolling_update", "rolling_downgrade", "rolling_version_change", "rollback", "nodeport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "secrets_used", "immutable_configmap" , "helm_deploy", "install_script_helm", "helm_chart_valid", "helm_chart_published", "chaos_network_loss", "chaos_cpu_hog", "chaos_container_kill", "volume_hostpath_not_found", "no_local_volume_configuration"])

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -239,13 +239,29 @@ module CNFManager
     def self.tasks_by_tag(tag)
       #TODO cross reference points.yml tags with results
       found = false
-      result_items =points_yml.reduce([] of String) do |acc, x|
+      result_items = points_yml.reduce([] of String) do |acc, x|
         # LOGGING.debug "tasks_by_tag: tag:#{tag}, points.name:#{x["name"].as_s?}, points.tags:#{x["tags"].as_s?}"
-        if x["tags"].as_s? && x["tags"].as_s.includes?(tag)
-          acc << x["name"].as_s
+        # TODO parse tags using ',' then get an exact match
+        if x["tags"].as_s? 
+          tags_list = x["tags"].as_s.split(",")
+          tag_match = tags_list.map { |parsed_tag|
+            LOGGING.debug "parsed_tag #{parsed_tag} tag: #{tag}"
+            parsed_tag if parsed_tag == tag
+          }.uniq.compact
+          LOGGING.debug "tag_match #{tag_match} name #{x["name"]}"
+          if !tag_match.empty?
+            acc << x["name"].as_s
+          else
+            acc
+          end
         else
           acc
         end
+        # if x["tags"].as_s? && x["tags"].as_s.includes?(tag)
+        #   acc << x["name"].as_s
+        # else
+        #   acc
+        # end
       end
     end
 


### PR DESCRIPTION
## Description
[BUG] tags for points.yml scores are getting added for workload reslilience tests when they're tagged as platform:resilience

## Issues:
Refs: #701

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
