### PR TITLE
[BUG] Debug type output is displayed when LOG_LEVEL=error

### DIFF
--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -221,7 +221,7 @@ module CNFManager
 
     unless CNFManager.exclusive_install_method_tags?(config)
       puts "Error: Must populate at lease one installation type in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}: choose either helm_chart, helm_directory, or manifest_directory in cnf-conformance.yml!".colorize(:red)
-      raise "Error: Must populate at lease one installation type in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}: choose either helm_chart, helm_directory, or manifest_directory in cnf-conformance.yml!"
+      exit 1
     end
     if !helm_chart.empty?
       {:helm_chart, helm_chart}
@@ -231,7 +231,7 @@ module CNFManager
       {:manifest_directory, manifest_directory}
     else
       puts "Error: Must populate at lease one installation type in #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}: choose either helm_chart, helm_directory, or manifest_directory.".colorize(:red)
-      raise "Error in cnf-conformance.yml!"
+      exit 1
     end
   end
 


### PR DESCRIPTION
[BUG] Debug type output is displayed when LOG_LEVEL=error

## Description
[BUG] Debug type output is displayed when LOG_LEVEL=error

## Issues:
Refs: #580

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
