### PR TITLE
[BUG] dockerd failed error when dockerd pod already installed on cluster #686

### DIFF
--- a/src/tasks/dockerd_setup.cr
+++ b/src/tasks/dockerd_setup.cr
@@ -10,7 +10,7 @@ task "install_dockerd" do |_, args|
   VERBOSE_LOGGING.info "install_dockerd" if check_verbose(args)
   resp = KubectlClient::Apply.file(dockerd_filename)
   status = check_dockerd(180)
-  if status
+  unless status
     LOGGING.error "Dockerd_Install failed.".colorize(:red)
   end
   LOGGING.info "Dockerd_Install status: #{status}"

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -19,7 +19,7 @@ module CNFManager
       @@file = CNFManager::Points.create_final_results_yml_name
       LOGGING.debug "Results.file"
       continue = false
-      LOGGING.info "file exists?:#{File.exists?(@@file)}"
+      # LOGGING.info "file exists?:#{File.exists?(@@file)}"
       if File.exists?("#{@@file}")
         stdout_info "Do you wish to overwrite the #{@@file} file? If so, your previous results.yml will be lost."
         print "(Y/N) (Default N): > "


### PR DESCRIPTION
## Description
[BUG] dockerd failed error when dockerd pod already installed on cluster #686

## Issues:
Refs: #686

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
